### PR TITLE
Add the flag data format and previous node to handler

### DIFF
--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -132,26 +132,16 @@ class TensorflowBackend(Backend):
       "dot": tf.contrib.keras.backend.dot,
       "exp": tf.exp,
       "floor": tf.floor,
-      "gather": tf.gather,
       "log": tf.log,
       "neg": tf.negative,
       "not": tf.logical_not,
       "pow": tf.pow,
-      "random_normal": tf.random_normal,
-      "random_uniform": tf.random_uniform,
       "reciprocal": tf.reciprocal,
       "reduce_log_sum_exp": tf.reduce_logsumexp,
-      "reduce_max": tf.reduce_max,
-      "reduce_mean": tf.reduce_mean,
-      "reduce_min": tf.reduce_min,
-      "reduce_prod": tf.reduce_prod,
-      "reduce_sum": tf.reduce_sum,
       "sigmoid": tf.sigmoid,
       "softplus": tf.nn.softplus,
       "sqrt": tf.sqrt,
-      "squeeze": tf.squeeze,
       "tanh": tf.tanh,
-      "transpose": tf.transpose,
   }
 
   tensor_type_to_tf_type = {
@@ -296,8 +286,10 @@ class TensorflowBackend(Backend):
     return op_func(x, y)
 
   @classmethod
-  def run_node(cls, node, inputs, device='CPU'):
+  def run_node(cls, node, inputs, device='CPU', channel_last=False):
     super(TensorflowBackend, cls).run_node(node, inputs, device)
+    cls._channel_last = channel_last
+    cls._device = device
     node = OnnxNode(node)
     device_option = get_device_option(Device(device))
     input_tensors = []
@@ -348,9 +340,14 @@ class TensorflowBackend(Backend):
 
       shape = list(d.dim_value for d in
                    value_info.type.tensor_type.shape.dim)
+      # If user specified channel last,
+      # shape must be set to format 'NHWC' whereas in ONNX is 'NCHW'
+      if cls._channel_last:
+        if len(shape) >= 3:
+          shape.insert(len(shape), shape.pop(1))
       x = tf.placeholder(cls.tensor_type_enum[
-          value_info.type.tensor_type.elem_type],
-                         name=value_info.name, shape=shape)
+                        value_info.type.tensor_type.elem_type],
+                        name=value_info.name, shape=shape)
       input_dict_items.append([value_info.name, x])
 
     # input dict: this dictionary is a map from variable names
@@ -382,9 +379,11 @@ class TensorflowBackend(Backend):
     return original_input_dict, predict_net
 
   @classmethod
-  def prepare(cls, model, device='CPU', **kwargs):
+  def prepare(cls, model, device='CPU', channel_last=False, **kwargs):
     super(TensorflowBackend, cls).prepare(model, device, **kwargs)
 
+    cls._channel_last = channel_last
+    cls._device = device
     original_input_dict, predict_net = (
         cls.onnx_graph_to_tensorflow_net(model.graph))
 
@@ -401,11 +400,17 @@ class TensorflowBackend(Backend):
     def tensor2list(onnx_tensor):
       # Use the onnx.numpy_helper because the data may be raw
       return onnx.numpy_helper.to_array(onnx_tensor).flatten().tolist()
-    input_dict = [(tp.name, tf.constant(tensor2list(tp),
-                                        shape=tp.dims,
-                                        dtype=cls.tensor_type_to_tf_type[
-                                            tp.data_type]))
-                  for tp in initializer]
+
+    input_dict = []
+    for i in initializer:
+      shape = i.dims[:]
+      if cls._channel_last:
+        if len(shape) >= 3:
+          shape.insert(len(shape), shape.pop(1))
+      input_dict.append((i.name,
+                         tf.constant(tensor2list(i),
+                                 dtype=cls.tensor_type_to_tf_type[i.data_type],
+                                 shape=shape)))
     return input_dict
 
   @classmethod
@@ -535,13 +540,8 @@ class TensorflowBackend(Backend):
 
   @classmethod
   def _pool(cls, node, input_dict, pool_func, can_pad_zero):
-    from math import ceil
 
     x = input_dict[node.inputs[0]]
-    x_rank = len(x.get_shape())
-
-    support_cuda = cls.supports_device("CUDA")
-    storage_format, compute_format = cls.get_data_format(x_rank, support_cuda)
 
     kernel_shape = node.attrs["kernel_shape"]
     strides = node.attrs["strides"]
@@ -561,15 +561,38 @@ class TensorflowBackend(Backend):
         # Currently it's always average pooling
         return cls._compatibility_avg_pool(node, input_dict, tf.nn.avg_pool, 0)
 
-    if support_cuda:
-      pooled = pool_func(x, [1, 1] + kernel_shape, [1, 1] + strides, pad,
-                         data_format=compute_format)
-    else:
+    # See https://github.com/onnx/onnx-tensorflow/issues/31#issuecomment-352019711
+    # for more details
+    if not cls._channel_last and cls._device in ["CPU"]:
       x = tf.transpose(x, perm=[0, 2, 3, 1])
-      pooled = pool_func(x, [1] + kernel_shape + [1], [1] + strides + [1], pad,
-                         data_format=compute_format)
-      pooled = tf.transpose(pooled, perm=[0, 3, 1, 2])
+      compute_format = 'NHWC'
+      kernel_shape = [1] + kernel_shape + [1]
+      strides = [1] + strides + [1]
+    elif cls._channel_last and cls._device in ["GPU"]:
+      x = tf.transpose(x, perm=[0, 3, 1, 2])
+      compute_format = 'NCHW'
+      kernel_shape = [1] + [1] + kernel_shape
+      strides = [1] + [1] + strides
+    elif not cls._channel_last and cls._device in ["GPU"]:
+      compute_format = 'NCHW'
+      kernel_shape = [1] + [1] + kernel_shape
+      strides = [1] + [1] + strides
+    if cls._channel_last and cls._device in ["CPU"]:
+      compute_format = 'NHWC'
+      kernel_shape = [1] + kernel_shape + [1]
+      strides = [1] + strides + [1]
 
+    pooled = pool_func(x, kernel_shape, strides, pad,
+                         data_format=compute_format)
+
+    if not cls._channel_last and cls._device in ["CPU"]:
+      pooled = tf.transpose(pooled, perm=[0, 3, 1, 2])
+    elif cls._channel_last and cls._device in ["GPU"]:
+      pooled = tf.transpose(pooled, perm=[0, 2, 3, 1])
+    elif cls._channel_last and cls._device in ["CPU"]:
+      pass
+    elif not cls._channel_last and cls._device in ["GPU"]:
+      pass
     return [pooled]
 
   @classmethod
@@ -590,10 +613,14 @@ class TensorflowBackend(Backend):
   def handle_batch_normalization(cls, node, input_dict):
     x = input_dict[node.inputs[0]]
     total_num_dim = len(x.get_shape())
-    scale = cls._explicit_broadcast(input_dict[node.inputs[1]], 1, total_num_dim)
-    bias = cls._explicit_broadcast(input_dict[node.inputs[2]], 1, total_num_dim)
-    mean = cls._explicit_broadcast(input_dict[node.inputs[3]], 1, total_num_dim)
-    variance = cls._explicit_broadcast(input_dict[node.inputs[4]], 1, total_num_dim)
+    b_dim = 1
+    if cls._channel_last:
+      if total_num_dim >= 3:
+        b_dim = total_num_dim - 1
+    scale = cls._explicit_broadcast(input_dict[node.inputs[1]], b_dim, total_num_dim)
+    bias = cls._explicit_broadcast(input_dict[node.inputs[2]], b_dim, total_num_dim)
+    mean = cls._explicit_broadcast(input_dict[node.inputs[3]], b_dim, total_num_dim)
+    variance = cls._explicit_broadcast(input_dict[node.inputs[4]], b_dim, total_num_dim)
 
     variance_epsilon = node.attrs.get("epsilon", 0.00001)
     if node.attrs.get("is_test", 0):
@@ -625,6 +652,17 @@ class TensorflowBackend(Backend):
     values = [input_dict[a] for a in node.inputs]
     # apparently this is what's needed for squeezenet to work
     axis = node.attrs.get("axis", 1)
+    # ONNX has data format to 'NC', so if the op need axis arg, 
+    # need to convert it to 'N...C' format
+    if cls._channel_last:
+      if len(values[0].shape) >= 3:
+        #if (axis == -1) or (axis==len(values[0].shape)-1):
+        if axis == 1:
+          axis = -1
+        elif axis == 0:
+          axis = 0
+        else:
+          axis = axis - 1
     return [tf.concat(values, axis=axis)]
 
   @classmethod
@@ -985,6 +1023,142 @@ class TensorflowBackend(Backend):
   def handle_mat_mul(cls, node, input_dict):
     return [tf.matmul(input_dict[node.inputs[0]],
                       input_dict[node.inputs[1]])]
+  @classmethod
+  def handle_squeeze(cls, node, input_dict):
+    axis = node.attrs["axes"]
+    # Arrange axis to the right data format
+    if cls._channel_last:
+      rank = len(input_dict[node.inputs[0]].shape)
+      if rank >= 3:
+        old_axis = axis[:]
+        for i, a in enumerate(old_axis):
+          if a == 1:
+            axis[i] = -1
+          elif a == 0:
+            axis[i] = 0
+          else:
+            axis[i] = a - 1
+    return [tf.squeeze(input_dict[node.inputs[0]], axis)]
+
+  @classmethod
+  def _reduce_op(cls, op, node, input_dict):
+    keep = bool(node.attrs["keepdims"])
+    axis = node.attrs["axes"]
+    # Arrange axis to the right data format
+    if cls._channel_last:
+      rank = len(input_dict[node.inputs[0]].shape)
+      if rank >= 3:
+        old_axis = axis[:]
+        for i, a in enumerate(old_axis):
+          if a == 1:
+            axis[i] = -1
+          elif a == 0:
+            axis[i] = 0
+          else:
+            axis[i] = a - 1
+    return [op(input_dict[node.inputs[0]], axis=axis, keep_dims=keep)]
+
+  @classmethod
+  def handle_reduce_max(cls, node, input_dict):
+    return cls._reduce_op(tf.reduce_max, node, input_dict)
+
+  @classmethod
+  def handle_reduce_mean(cls, node, input_dict):
+    return cls._reduce_op(tf.reduce_mean, node, input_dict)
+
+  @classmethod
+  def handle_reduce_min(cls, node, input_dict):
+    return cls._reduce_op(tf.reduce_min, node, input_dict)
+
+  @classmethod
+  def handle_reduce_prod(cls, node, input_dict):
+    return cls._reduce_op(tf.reduce_prod, node, input_dict)
+
+  @classmethod
+  def handle_reduce_sum(cls, node, input_dict):
+    return cls._reduce_op(tf.reduce_sum, node, input_dict)
+
+  @classmethod
+  def handle_transpose(cls, node, input_dict):
+    perm = node.attrs["perm"]
+    # Arrange perm to the right data format
+    if cls._channel_last:
+      rank = len(input_dict[node.inputs[0]].shape)
+      if rank >= 3:
+        old_perm = perm[:]
+        for i, p in enumerate(old_perm):
+          if p == 1:
+            new_i = 1
+            new_p = 1
+          elif p == 0:
+            new_i = 0
+            new_p = 0
+          else:
+            new_i = i - 1
+            new_p = p - 1
+          perm[new_i] = new_p
+    return [tf.transpose(input_dict[node.inputs[0]], perm=perm)]
+
+  @classmethod
+  def handle_random_normal(cls, node, input_dict):
+    mean = node.attrs["mean"]
+    stddev = node.attrs["scale"]
+    dtype = cls.tensor_type_to_tf_type[node.attrs["dtype"]]
+    seed = node.attrs["seed"] if "seed" in node.attrs.keys() else None
+    #shape = tf.shape(input_dict[node.inputs[0]])
+    shape = np.asarray(node.attrs["shape"])
+    # Arrange shape to the right data format
+    new_shape = shape[:]
+    if cls._channel_last:
+      if len(shape) >= 3:
+        for i, s in enumerate(shape):
+          if i == 1:
+            new_i = 1
+          elif i == 0:
+            new_i = 0
+          else:
+            new_i = i - 1
+          new_shape[new_i] = s
+    return [tf.random_normal(shape, mean, stddev, dtype, seed)]
+
+  @classmethod
+  def handle_random_uniform(cls, node, input_dict):
+    minval = node.attrs["low"]
+    maxval = node.attrs["high"]
+    dtype = cls.tensor_type_to_tf_type[node.attrs["dtype"]]
+    seed = node.attrs["seed"] if "seed" in node.attrs.keys() else None
+    shape = np.asarray(node.attrs["shape"])
+    # Arrange shape to the right data format
+    if cls._channel_last:
+      if len(shape) >= 3:
+        old_shape = shape[:]
+        for i, s in enumerate(old_shape):
+          if i == 1:
+            new_i = 1
+          elif i == 0:
+            new_i = 0
+          else:
+            new_i = i - 1
+          shape[new_i] = s
+    return [tf.random_uniform(shape, minval, maxval, dtype, seed)]
+
+  @classmethod
+  def handle_gather(cls, node, input_dict):
+    params = input_dict[node.inputs[0]]
+    indices = input_dict[node.inputs[1]]
+    axis = node.attrs.get("axis", 0)
+    # TODO : Arrange indices to the right data format
+    # Arrange axis to the right data format
+    if cls._channel_last:
+      rank = len(input_dict[node.inputs[0]].shape)
+      if rank >= 3:
+        if a == 1:
+          axis = -1
+        elif a == 0:
+          axis = 0
+        else:
+          axis = a - 1
+    return [tf.gather(params, indices=indices, axis=axis)]
 
   @classmethod
   def supports_device(cls, device):

--- a/test/backend/test_model.py
+++ b/test/backend/test_model.py
@@ -27,6 +27,7 @@ class TestModel(unittest.TestCase):
       inputs=[helper.make_tensor_value_info("X", TensorProto.FLOAT, [3, 2])],
       outputs=[helper.make_tensor_value_info("X1", TensorProto.FLOAT, [3, 2])])
     tf_rep = prepare(helper.make_model(graph_def))
+
     output = tf_rep.run({"X": X})
     np.testing.assert_almost_equal(output.X1, Y_ref)
 

--- a/test/backend/test_onnx_backend.py
+++ b/test/backend/test_onnx_backend.py
@@ -33,9 +33,9 @@ if 'TRAVIS' in os.environ:
     backend_test.exclude('test_vgg19')
 
 # import all test cases at global scope to make them visible to python.unittest
+
 globals().update(backend_test
                  .enable_report()
                  .test_cases)
-
 if __name__ == '__main__':
     unittest.main()

--- a/test/frontend/test_node.py
+++ b/test/frontend/test_node.py
@@ -38,13 +38,15 @@ class TestNode(unittest.TestCase):
   pass
 
 def create_test(test_data):
-  test_option = test_data[5] if len(test_data) > 5 else {}
+  test_option = test_data[7] if len(test_data) > 7 else {}
 
   def do_test_expected(self):
     tf_op = test_data[1]
     output_name = test_data[2]
     inputs = test_data[3]
     attrs = test_data[4]
+    device = test_data[5]
+    channel_last = test_data[6]
 
     # Now construct input feed dict
     # keyed by input name
@@ -58,6 +60,7 @@ def create_test(test_data):
                                      shape=input_tensor.shape,
                                      name="in_" + str(idx))
         onnx_feed_dict["in_" + str(idx)] = input_tensor
+        # TF have to get input in format : NHWC
         tf_feed_dict[placeholder] = input_tensor
         tf_param_list.append(placeholder)
       else:
@@ -66,9 +69,10 @@ def create_test(test_data):
     tf_graph = tf.get_default_graph().as_graph_def(add_shapes=True)
     # Construct onnx graph, run with backend.
     output_node = get_node_by_name(tf_graph.node, output_name)
-    onnx_graph = convert_graph(tf_graph, output_node)
+    onnx_graph = convert_graph(tf_graph, output_node, device=device,
+            channel_last=channel_last)
     onnx_model = helper.make_model(onnx_graph)
-    backend_rep = prepare(onnx_model)
+    backend_rep = prepare(onnx_model, device=device, channel_last=channel_last)
     backend_output = backend_rep.run(onnx_feed_dict)[output_name]
 
     with tf.Session() as sess:
@@ -90,28 +94,47 @@ def create_test(test_data):
 # in the sense that numpy array are passed in via tf.placeholder
 # whereas python arrays are passed in as constants.
 test_cases = [
-("test_relu", tf.nn.relu, "Relu", [get_rnd([10, 10])], {}),
-("test_or", tf.logical_or, "LogicalOr", [get_rnd([10, 10], dtype=np.bool_), get_rnd([10, 10], dtype=np.bool_)], {}),
-("test_pow", tf.pow, "Pow", [get_rnd([10, 10]), get_rnd([10, 10])], {}),
-("test_pad", tf.pad, "Pad", [get_rnd([2, 3]), [[1, 1,], [2, 2]]], {"mode": "constant"}),
-("test_random_normal", tf.random_normal, "random_normal/RandomStandardNormal", [], {"shape": [100, 100], "mean": 0.0, "stddev": 1.0, "dtype": tf.float32, "seed": 42}, {"call_only": True}),
-("test_random_uniform", tf.random_uniform, "random_uniform", [], {"shape": [100, 100], "minval": 0.0, "maxval": 1.0, "dtype": tf.float32, "seed": 42}, {"call_only": True}),
-("test_reciprocal", tf.reciprocal, "Reciprocal", [get_rnd([10, 10])], {}),
-("test_reduce_max", tf.reduce_max, "Max", [get_rnd([10, 10])], {"keep_dims": True}),
-("test_reduce_mean", tf.reduce_mean, "Mean", [get_rnd([10, 10])], {"keep_dims": True}),
-("test_reduce_min", tf.reduce_min, "Min", [get_rnd([10, 10])], {"keep_dims": True}),
-("test_reduce_prod", tf.reduce_prod, "Prod", [get_rnd([10, 10])], {"keep_dims": True}),
-("test_reduce_sum", tf.reduce_sum, "Sum", [get_rnd([10, 10])], {"keep_dims": True}),
-("test_reshape", tf.reshape, "Reshape", [get_rnd([10, 10]), [4, 25]], {}),
-("test_sigmoid", tf.sigmoid, "Sigmoid", [get_rnd([10, 10])], {}),
-("test_split", tf.split, "split", [get_rnd([10, 10]), [5, 5]], {}),
-("test_sqrt", tf.sqrt, "Sqrt", [get_rnd([10, 10])], {}),
-("test_squeeze", tf.squeeze, "Squeeze", [get_rnd([1, 1, 10, 10])], {"axis":[0, 1]}),
-("test_subtract", tf.subtract, "Sub", [get_rnd([10, 10]), get_rnd([10, 10])], {}),
-("test_tanh", tf.tanh, "Tanh", [get_rnd([10, 10])], {}),
-("test_xor", tf.logical_xor, "LogicalXor", [get_rnd([10, 10], dtype=np.bool_), get_rnd([10, 10], dtype=np.bool_)], {}),
-("test_transpose", tf.transpose, "transpose", [get_rnd([2, 10])], {"perm":[1, 0]}),
-("test_concat", tf.concat, "concat", [[get_rnd([1, 10]),get_rnd([10, 10]),get_rnd([20, 10])], 0], {})
+("test_relu", tf.nn.relu, "Relu", [get_rnd([10, 10])], {}, 'CPU', True),
+("test_or", tf.logical_or, "LogicalOr", [get_rnd([10, 10], dtype=np.bool_), get_rnd([10, 10], dtype=np.bool_)], {}, 'CPU', True),
+("test_pow", tf.pow, "Pow", [get_rnd([10, 10]), get_rnd([10, 10])], {}, 'CPU', True),
+("test_pad", tf.pad, "Pad", [get_rnd([2, 3]), [[1, 1,], [2, 2]]], {"mode": "constant"}, 'CPU', True),
+("test_random_normal", tf.random_normal, "random_normal/RandomStandardNormal", [], {"shape": [1, 100, 100, 1], "mean": 0.0, "stddev": 1.0, "dtype": tf.float32, "seed": 42}, 'CPU', True, {"call_only": True}),
+("test_random_normal", tf.random_normal, "random_normal/RandomStandardNormal", [], {"shape": [100, 100], "mean": 0.0, "stddev": 1.0, "dtype": tf.float32, "seed": 42}, 'CPU', True, {"call_only": True}),
+("test_random_uniform", tf.random_uniform, "random_uniform", [], {"shape": [100, 100], "minval": 0.0, "maxval": 1.0, "dtype": tf.float32, "seed": 42}, 'CPU', True, {"call_only": True}),
+("test_random_uniform", tf.random_uniform, "random_uniform", [], {"shape": [1, 42, 42, 3], "minval": 0.0, "maxval": 1.0, "dtype": tf.float32, "seed": 42}, 'CPU', True, {"call_only": True}),
+("test_reciprocal", tf.reciprocal, "Reciprocal", [get_rnd([10, 10])], {}, 'CPU', True),
+("test_reduce_max", tf.reduce_max, "Max", [get_rnd([10, 10, 10, 10])], {"axis": [0, 1, 2, 3], "keep_dims": True}, 'CPU', True),
+("test_reduce_max", tf.reduce_max, "Max", [get_rnd([10, 10])], {"keep_dims": True}, 'CPU', True),
+("test_reduce_mean", tf.reduce_mean, "Mean", [get_rnd([10, 10])], {"keep_dims": True}, 'CPU', True),
+("test_reduce_min", tf.reduce_min, "Min", [get_rnd([10, 10])], {"keep_dims": True}, 'CPU', True),
+("test_reduce_prod", tf.reduce_prod, "Prod", [get_rnd([10, 10])], {"keep_dims": True}, 'CPU', True),
+("test_reduce_prod", tf.reduce_prod, "Prod", [get_rnd([1, 10, 10, 3])], {"axis": [1, 2], "keep_dims": True}, 'CPU', True),
+("test_reduce_sum", tf.reduce_sum, "Sum", [get_rnd([10, 10])], {"keep_dims": True}, 'CPU', True),
+("test_reduce_sum", tf.reduce_sum, "Sum", [get_rnd([1, 10, 10, 3])], {"axis": [1, 2], "keep_dims": True}, 'CPU', True),
+("test_reshape", tf.reshape, "Reshape", [get_rnd([1, 16, 16, 3]), [1, 16*16, 3]], {}, 'CPU', True),
+("test_reshape", tf.reshape, "Reshape", [get_rnd([1, 16, 16, 3]), [3, 16*16]], {}, 'CPU', True),
+("test_reshape", tf.reshape, "Reshape", [get_rnd([1, 16, 16, 3]), [3, 16, 16]], {}, 'CPU', True),
+("test_reshape", tf.reshape, "Reshape", [get_rnd([1, 16, 16, 1]), [16, 16]], {}, 'CPU', True),
+("test_reshape", tf.reshape, "Reshape", [get_rnd([10, 10]), [4, 25]], {}, 'CPU', True),
+("test_sigmoid", tf.sigmoid, "Sigmoid", [get_rnd([10, 10])], {}, 'CPU', True),
+("test_split", tf.split, "split", [get_rnd([1, 10, 10, 3]), [1, 5, 5, 1]], {}, 'CPU', True),
+("test_split", tf.split, "split", [get_rnd([10, 10]), [5, 5]], {}, 'CPU', True),
+("test_sqrt", tf.sqrt, "Sqrt", [get_rnd([10, 10])], {}, 'CPU', True),
+("test_squeeze", tf.squeeze, "Squeeze", [get_rnd([1, 1, 1, 1])], {"axis":[0, 3, 2, 1]}, 'CPU', True),
+("test_squeeze", tf.squeeze, "Squeeze", [get_rnd([1, 10, 10])], {"axis":[0]}, 'CPU', True),
+("test_squeeze", tf.squeeze, "Squeeze", [get_rnd([1, 10, 10, 1])], {"axis":[0, 3]}, 'CPU', True),
+("test_squeeze", tf.squeeze, "Squeeze", [get_rnd([10, 1, 1, 3])], {"axis":[1, 2]}, 'CPU', True),
+("test_subtract", tf.subtract, "Sub", [get_rnd([10, 10]), get_rnd([10, 10])], {}, 'CPU', True),
+("test_tanh", tf.tanh, "Tanh", [get_rnd([10, 10])], {}, 'CPU', True),
+("test_xor", tf.logical_xor, "LogicalXor", [get_rnd([10, 10], dtype=np.bool_), get_rnd([10, 10], dtype=np.bool_)], {}, 'CPU', True),
+("test_transpose", tf.transpose, "transpose", [get_rnd([1, 3, 2, 10])], {"perm":[2, 3, 1, 0]}, 'CPU', True),
+("test_transpose", tf.transpose, "transpose", [get_rnd([1, 16, 16, 3])], {"perm":[0, 3, 1, 2]}, 'CPU', True),
+("test_transpose", tf.transpose, "transpose", [get_rnd([1, 2, 2, 10])], {"perm":[3, 1, 2, 0]}, 'CPU', True),
+("test_transpose", tf.transpose, "transpose", [get_rnd([2, 10])], {"perm":[1, 0]}, 'CPU', True),
+("test_concat", tf.concat, "concat", [[get_rnd([2, 1]), get_rnd([2, 2]), get_rnd([2, 1])], 1], {}, 'CPU', True),
+("test_concat", tf.concat, "concat", [[get_rnd([2, 1, 2]), get_rnd([2, 2, 2]), get_rnd([2, 1, 2])], 1], {}, 'CPU', True),
+("test_concat", tf.concat, "concat", [[get_rnd([1, 10, 10, 1]), get_rnd([1, 10, 10, 1]), get_rnd([1, 10, 10, 1])], 3], {}, 'CPU', True),
+("test_concat", tf.concat, "concat", [[get_rnd([1, 10, 10, 1]), get_rnd([1, 10, 10, 1]), get_rnd([1, 10, 10, 1])], 0], {}, 'CPU', True),
 ]
 
 for k, val in enumerate(test_cases):


### PR DESCRIPTION
* Add a parameter for all handler front-end functions to give the previous nodes to the current node in the graph in order to be able to get the input shape tensor for examples
* Add a flag that user can specify in order to know when converting to/from TF which data format it is used. Then, it is possible to add transpose of to change parameters (axis, perm, shape, etc)