### PR TITLE
fix frontend API verbosity

### DIFF
--- a/onnx_tf/doc/API.md
+++ b/onnx_tf/doc/API.md
@@ -68,8 +68,8 @@ _params_:
 `graph_def` : Tensorflow Graph Proto object.
 
 
-`output` : A Tensorflow NodeDef object specifying which node
-to be taken as output of the ONNX graph.
+`output` : A string specifying the name of the output
+graph node.
 
 
 `opset` : Opset version of the operator set.

--- a/onnx_tf/frontend.py
+++ b/onnx_tf/frontend.py
@@ -278,8 +278,8 @@ class TensorflowFrontendBase(object):
     representation of ONNX model.
 
     :param graph_def: Tensorflow Graph Proto object.
-    :param output: A Tensorflow NodeDef object specifying which node
-      to be taken as output of the ONNX graph.
+    :param output: A string specifying the name of the output
+      graph node.
     :param opset: Opset version of the operator set.
       Default 0 means using latest version.
     :param producer_name: The name of the producer.
@@ -287,7 +287,14 @@ class TensorflowFrontendBase(object):
 
     :returns: The equivalent ONNX Model Proto object.
     """
-    onnx_graph = cls.tensorflow_graph_to_onnx_graph(graph_def, output, opset,
+    def get_node_by_name(nodes, name):
+      for node in nodes:
+        if node.name == name:
+          return node
+      raise ValueError("Node {} is not found in the graph provided".format(name))
+
+    output_node = get_node_by_name(graph_def.node, output)
+    onnx_graph = cls.tensorflow_graph_to_onnx_graph(graph_def, output_node, opset,
                                                     graph_name)
     onnx_model = make_model(
         onnx_graph,


### PR DESCRIPTION
Frontend API for now is too verbose mainly because we have to find the output node oursevles. 

Currently we have:
```
def get_node_by_name(nodes, name):
  for node in nodes:
    if node.name == name:
      return node

with tf.gfile.GFile(graph_pb, "rb") as f:
	graph_def = tf.GraphDef()
	graph_def.ParseFromString(f.read())
	onnx_model = tensorflow_graph_to_onnx_model(graph_def,
                                     get_node_by_name(graph_def.node, "fc2/add"),
                                     opset=6,
                                     producer_name="onnx-tensorflow",
                                     graph_name="graph")
```
Proposing to change to 
```
onnx_model = tensorflow_graph_to_onnx_model(graph_def,
                                     "fc2/add",
                                     opset=6,
                                     producer_name="onnx-tensorflow",
                                     graph_name="graph")
```

