### PR TITLE
remove requires of tensorflow and numpy in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## To install:
 Firstly install [ONNX](https://github.com/onnx/onnx) which cannot be installed by pip unless protoc is available.
 
-Secondly install Tensorflow.
+Secondly install Tensorflow>=1.5.0.
 
 Then, run `pip install onnx-tf`
 
@@ -33,7 +33,7 @@ The result is `[ 0.   0.1]`
 
 ## Development Install:
 - Install ONNX
-- Install Tensorflow
+- Install Tensorflow>=1.5.0
 - Run `git clone git@github.com:onnx/onnx-tensorflow.git && cd onnx-tensorflow`
 - Run `pip install -e .`
 - Development follows conventions [here](https://github.com/onnx/onnx-caffe2/blob/master/onnx_caffe2/backend.py)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 ## To install:
 Firstly install [ONNX](https://github.com/onnx/onnx) which cannot be installed by pip unless protoc is available.
 
+Secondly install Tensorflow.
+
 Then, run `pip install onnx-tf`
 
 ## To test:
@@ -31,6 +33,7 @@ The result is `[ 0.   0.1]`
 
 ## Development Install:
 - Install ONNX
+- Install Tensorflow
 - Run `git clone git@github.com:onnx/onnx-tensorflow.git && cd onnx-tensorflow`
 - Run `pip install -e .`
 - Development follows conventions [here](https://github.com/onnx/onnx-caffe2/blob/master/onnx_caffe2/backend.py)

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,7 @@ setup(
     name='onnx-tf',
     version='1.0',
     description='Tensorflow backend for ONNX (Open Neural Network Exchange).',
-    # as per https://github.com/tensorflow/tensorflow/issues/16488
-    # need to bump numpy version manually.
-    install_requires=['onnx', 'tensorflow', 'numpy>=1.14'],
+    install_requires=['onnx'],
     url='https://github.com/tjingrant',
     author='Arpith Jacob, Tian Jin, Gheorghe-Teodor Bercea',
     author_email='tian.jin1@ibm.com',


### PR DESCRIPTION
@tjingrant 
I know we need tensorflow to do both backend and frontend.
But in practice, not only tensorflow, tensorflow-gpu is also used widely. 
(Actually it's my case) I have to switch environment to do convert.
I think remove them from setup.py and let user install deps by themselves is a better idea.
numpy problem is fixed so remove it also.
What do you think?