### PR TITLE
introduce data type caster

### DIFF
--- a/onnx_tf/frontend.py
+++ b/onnx_tf/frontend.py
@@ -306,7 +306,7 @@ class TensorflowFrontendBase(object):
   @classmethod
   def _data_type_caster(cls, protos, data_type_cast_map):
     """Cast to a new data type if node name is in data_type_cast_map.
-    Be used to precess protos to match ONNX type constraints.
+    Be used to process protos to match ONNX type constraints.
 
     :param protos: Target protos.
       TensorProto for inputs and ValueInfoProto for consts.
@@ -318,20 +318,21 @@ class TensorflowFrontendBase(object):
     result = []
     for proto in protos:
       new_proto = proto
-      if proto.name in data_type_cast_map \
-          and proto.data_type != data_type_cast_map[proto.name]:
-        if type(proto) == TensorProto:
+      if proto.name in data_type_cast_map:
+        new_data_type = data_type_cast_map[proto.name]
+        if type(proto) == TensorProto and proto.data_type != new_data_type:
           field = mapping.STORAGE_TENSOR_TYPE_TO_FIELD[
               mapping.TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE[proto.data_type]]
           vals = getattr(proto, field)
           new_proto = make_tensor(
               name=proto.name,
-              data_type=data_type_cast_map[proto.name],
+              data_type=new_data_type,
               dims=proto.dims,
               vals=vals)
-        elif type(proto) == ValueInfoProto \
-            and proto.type.tensor_type.elem_type != data_type_cast_map[proto.name]:
-          new_proto.type.tensor_type.elem_type = data_type_cast_map[proto.name]
+        elif type(
+            proto
+        ) == ValueInfoProto and proto.type.tensor_type.elem_type != new_data_type:
+          new_proto.type.tensor_type.elem_type = new_data_type
       result.append(new_proto)
     return result
 

--- a/onnx_tf/frontend.py
+++ b/onnx_tf/frontend.py
@@ -33,7 +33,9 @@ from onnx.helper import (
     make_node,
     make_opsetid,
 )
-from onnx.onnx_pb2 import GraphProto, TensorProto, AttributeProto
+from onnx.helper import mapping
+from onnx.onnx_pb2 import TensorProto
+from onnx.onnx_pb2 import ValueInfoProto
 
 
 class TensorflowNode(object):
@@ -165,6 +167,10 @@ class TensorflowFrontendBase(object):
     # representing the all nodes' outputs to the converted ONNX graph.
     value_info_proto = []
 
+    # A map holds nodes name and new data type. Will be used to
+    # process protos to match ONNX type constraints.
+    data_type_cast_map = {}
+
     node_tup = [(node.name, TensorflowNode(node)) for node in graph_def.node]
 
     for name, node in node_tup:
@@ -251,7 +257,11 @@ class TensorflowFrontendBase(object):
         # Check if specialized handler exists.
         if hasattr(frontend, handler_name):
           method_to_call = getattr(frontend, handler_name)
-          node = method_to_call(node, consts=consts, node_dict=dict(node_tup))
+          node = method_to_call(
+              node,
+              consts=consts,
+              node_dict=dict(node_tup),
+              data_type_cast_map=data_type_cast_map)
           if isinstance(node, list):
             ops_proto.extend(node)
           else:
@@ -282,6 +292,9 @@ class TensorflowFrontendBase(object):
     inputs_proto = list(filter(lambda x: x.name in inputs, inputs_proto))
     consts_proto = list(filter(lambda x: x.name in inputs, consts_proto))
 
+    inputs_proto = cls._data_type_caster(inputs_proto, data_type_cast_map)
+    consts_proto = cls._data_type_caster(consts_proto, data_type_cast_map)
+
     return make_graph(
         ops_proto,
         name,
@@ -289,6 +302,38 @@ class TensorflowFrontendBase(object):
         output_proto,
         initializer=consts_proto,
         value_info=value_info_proto)
+
+  @classmethod
+  def _data_type_caster(cls, protos, data_type_cast_map):
+    """Cast to a new data type if node name is in data_type_cast_map.
+    Be used to precess protos to match ONNX type constraints.
+
+    :param protos: Target protos.
+      TensorProto for inputs and ValueInfoProto for consts.
+    :param data_type_cast_map: A {node.name: new_data_type} dict.
+    :return: Processed protos.
+    """
+    if not data_type_cast_map:
+      return protos
+    result = []
+    for proto in protos:
+      new_proto = proto
+      if proto.name in data_type_cast_map \
+          and proto.data_type != data_type_cast_map[proto.name]:
+        if type(proto) == TensorProto:
+          field = mapping.STORAGE_TENSOR_TYPE_TO_FIELD[
+              mapping.TENSOR_TYPE_TO_STORAGE_TENSOR_TYPE[proto.data_type]]
+          vals = getattr(proto, field)
+          new_proto = make_tensor(
+              name=proto.name,
+              data_type=data_type_cast_map[proto.name],
+              dims=proto.dims,
+              vals=vals)
+        elif type(proto) == ValueInfoProto \
+            and proto.type.tensor_type.elem_type != data_type_cast_map[proto.name]:
+          new_proto.type.tensor_type.elem_type = data_type_cast_map[proto.name]
+      result.append(new_proto)
+    return result
 
   @classmethod
   def tensorflow_graph_to_onnx_model(cls,

--- a/onnx_tf/frontends/frontend_v1.py
+++ b/onnx_tf/frontends/frontend_v1.py
@@ -225,6 +225,9 @@ class TensorflowFrontend(TensorflowFrontendBase):
   @classmethod
   @register_onnx_op("Tile")
   def handle_tile(cls, node, **kwargs):
+    if kwargs["node_dict"][node.inputs[1]].attr["dtype"] != TensorProto.INT64:
+      data_type_cast_map = kwargs["data_type_cast_map"]
+      data_type_cast_map[node.inputs[1]] = TensorProto.INT64
     return helper.make_node("Tile", node.inputs, [node.name])
 
   @classmethod

--- a/onnx_tf/frontends/frontend_v1.py
+++ b/onnx_tf/frontends/frontend_v1.py
@@ -225,9 +225,8 @@ class TensorflowFrontend(TensorflowFrontendBase):
   @classmethod
   @register_onnx_op("Tile")
   def handle_tile(cls, node, **kwargs):
-    if kwargs["node_dict"][node.inputs[1]].attr["dtype"] != TensorProto.INT64:
-      data_type_cast_map = kwargs["data_type_cast_map"]
-      data_type_cast_map[node.inputs[1]] = TensorProto.INT64
+    data_type_cast_map = kwargs["data_type_cast_map"]
+    data_type_cast_map[node.inputs[1]] = TensorProto.INT64
     return helper.make_node("Tile", node.inputs, [node.name])
 
   @classmethod

--- a/test/frontend/test_node.py
+++ b/test/frontend/test_node.py
@@ -118,6 +118,7 @@ test_cases = [
 ("test_squeeze", tf.squeeze, "Squeeze", [get_rnd([1, 1, 10, 10])], {"axis":[0, 1]}),
 ("test_subtract", tf.subtract, "Sub", [get_rnd([10, 10]), get_rnd([10, 10])], {}),
 ("test_tanh", tf.tanh, "Tanh", [get_rnd([10, 10])], {}),
+("test_tile", tf.tile, "Tile", [get_rnd([1, 2, 3, 4]), np.random.randint(1, 10, (4,), dtype=np.int32)], {}),
 ("test_xor", tf.logical_xor, "LogicalXor", [get_rnd([10, 10], dtype=np.bool_), get_rnd([10, 10], dtype=np.bool_)], {}),
 ("test_transpose", tf.transpose, "transpose", [get_rnd([2, 10])], {"perm":[1, 0]}),
 ("test_concat", tf.concat, "concat", [[get_rnd([1, 10]),get_rnd([10, 10]),get_rnd([20, 10])], 0], {})


### PR DESCRIPTION
Introduce data type caster in frontend.
Mainly used for casting data type which is different from tf.
For example, [`Tile`](https://github.com/onnx/onnx/blob/master/docs/Operators.md#tile) has type `int64` for `repeats` which could be `int32`, `int64` in [tf](https://www.tensorflow.org/api_docs/python/tf/tile).