### PR TITLE
include VERSION_NUMBER, ONNX_VERSION_NUMBER in pypi distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include LICENSE
+include VERSION_NUMBER
+include ONNX_VERSION_NUMBER


### PR DESCRIPTION
Without this, the package isn't installable from pip. For example, [this build](https://circleci.com/gh/conda-forge/onnx-tf-feedstock/58?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link), which is basically equivalent to this:
```
$ conda create -n tmp -c conda-forge onnx
[...]
$ conda activate tmp
$ pip install onnx-tf
Collecting onnx-tf
  Downloading https://files.pythonhosted.org/packages/d1/20/544cec0c523e68eed30f3990a70897c43ef326407189f43c0f4fbb9f32b2/onnx-tf-1.1.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-owqdmri1/onnx-tf/setup.py", line 6, in <module>
        with open(os.path.join(TOP_DIR, 'VERSION_NUMBER')) as version_file:
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-build-owqdmri1/onnx-tf/VERSION_NUMBER'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-owqdmri1/onnx-tf/
```

This is because the `VERSION_NUMBER` and `ONNX_VERSION_NUMBER` files aren't included in the pypi distribution. Adding them to `MANIFEST.in` fixes that.