### PR TITLE
add imagescaler support to backend

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -49,7 +49,7 @@ ______
 |Hardmax|1|
 |Identity|1|
 |If|N/A|
-|ImageScaler|N/A|
+|ImageScaler|1|
 |InstanceNormalization|1, 6|
 |LRN|1|
 |LSTM|1, 7|

--- a/onnx_tf/handlers/backend/image_scaler.py
+++ b/onnx_tf/handlers/backend/image_scaler.py
@@ -1,0 +1,19 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+
+
+@onnx_op("ImageScaler")
+class ImageScaler(BackendHandler):
+
+  @classmethod
+  def version_1(cls, node, **kwargs):
+    input_dict = kwargs["tensor_dict"]
+    x = input_dict[node.inputs[0]]
+    scale = node.attrs.get("scale", 1.0)
+    output = tf.multiply(x, scale)
+    if "bias" in node.attrs:
+      bias = node.attrs["bias"]
+      output = tf.nn.bias_add(output, bias, data_format="NCHW")
+    return [output]

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -42,7 +42,7 @@ backend_opset_version = {
     'Hardmax': [1],
     'Identity': [1],
     'If': [],
-    'ImageScaler': [],
+    'ImageScaler': [1],
     'InstanceNormalization': [1, 6],
     'LRN': [1],
     'LSTM': [1, 7],

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -394,6 +394,26 @@ class TestNode(unittest.TestCase):
         test_output[i1][i2][0][0] = sum / 6.
     np.testing.assert_almost_equal(output["Y"], test_output)
 
+  def test_image_sacler(self):
+    # Input:  (N x C x H x W), where N is the batch size,
+    # C is the number of channels, and H and W are the height
+    # and the width of the data
+    # Scale: (flout, default 1.0) the scale to apply
+    # Bias: applied to each channel, same size as C
+    # Output has same shape and type as input
+    x = self._get_rnd([1, 3, 224, 224])
+    #random distribution over [0,1), so add 0.1
+    scale = np.random.rand(1)[0] + 0.1
+    bias = np.random.rand(3)
+    node_def = helper.make_node(
+        "ImageScaler", ["X"], ["Y"], scale=scale, bias=bias)
+    output = run_node(node_def, [x])
+    test_out = np.multiply(x, scale)
+    test_out = np.transpose(test_out, [0, 2, 3, 1])
+    test_out = np.add(test_out, bias)
+    test_out = np.transpose(test_out, [0, 3, 1, 2])
+    np.testing.assert_almost_equal(output["Y"], test_out)
+
   def test_global_lp_pool(self):
     #   Image case:  (N x C x H x W), where N is the batch size,
     # C is the number of channels, and H and W are the height


### PR DESCRIPTION
Scale and bias the input image.
In the onnx difinition:
* Input tensor has shape [N,C,H,W].
* Output has same shape and type as input.
* Bias applied to each channel, same size as C.