### PR TITLE
force to use test mode in bn v7

### DIFF
--- a/onnx_tf/common/__init__.py
+++ b/onnx_tf/common/__init__.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
 import re
 import sys
 import uuid
@@ -11,6 +12,10 @@ from onnx.backend.base import DeviceType
 from tensorflow.python.client import device_lib
 
 IS_PYTHON3 = sys.version_info > (3,)
+
+
+def is_test():
+  return os.environ.get("TRAVIS", 0) == 1 or "PYTEST_CURRENT_TEST" in os.environ
 
 
 # This function inserts an underscore before every upper

--- a/onnx_tf/common/__init__.py
+++ b/onnx_tf/common/__init__.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
 import re
 import sys
 import uuid
@@ -12,10 +11,6 @@ from onnx.backend.base import DeviceType
 from tensorflow.python.client import device_lib
 
 IS_PYTHON3 = sys.version_info > (3,)
-
-
-def is_test():
-  return os.environ.get("TRAVIS", 0) == 1 or "PYTEST_CURRENT_TEST" in os.environ
 
 
 # This function inserts an underscore before every upper

--- a/onnx_tf/common/__init__.py
+++ b/onnx_tf/common/__init__.py
@@ -15,7 +15,7 @@ IS_PYTHON3 = sys.version_info > (3,)
 
 
 def is_test():
-  return os.environ.get("TRAVIS", 0) == 1 or "PYTEST_CURRENT_TEST" in os.environ
+  return os.getenv("TRAVIS") or "PYTEST_CURRENT_TEST" in os.environ
 
 
 # This function inserts an underscore before every upper

--- a/onnx_tf/common/__init__.py
+++ b/onnx_tf/common/__init__.py
@@ -15,7 +15,7 @@ IS_PYTHON3 = sys.version_info > (3,)
 
 
 def is_test():
-  return os.getenv("TRAVIS") or "PYTEST_CURRENT_TEST" in os.environ
+  return os.environ.get("TRAVIS", 0) == 1 or "PYTEST_CURRENT_TEST" in os.environ
 
 
 # This function inserts an underscore before every upper

--- a/onnx_tf/handlers/backend/batch_normalization.py
+++ b/onnx_tf/handlers/backend/batch_normalization.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 
+from onnx_tf.common import is_test
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
@@ -38,8 +39,8 @@ class BatchNormalization(BackendHandler):
     running_variance = tf.reshape(tensor_dict[node.inputs[4]],
                                   params_shape_broadcast)
 
-    # from version 7, force to use test mode
-    if cls.SINCE_VERSION >= 7 or node.attrs.get("is_test", 0):
+    # force to use test mode since v7 with CI test
+    if node.attrs.get("is_test", 0) or (cls.SINCE_VERSION >= 7 and is_test()):
       inputs = [x, running_mean, running_variance, bias, scale]
       return [cls.make_tensor_from_onnx_node(node, inputs=inputs)]
     spatial = node.attrs.get("spatial", 1) == 1

--- a/onnx_tf/handlers/backend/batch_normalization.py
+++ b/onnx_tf/handlers/backend/batch_normalization.py
@@ -38,7 +38,8 @@ class BatchNormalization(BackendHandler):
     running_variance = tf.reshape(tensor_dict[node.inputs[4]],
                                   params_shape_broadcast)
 
-    if node.attrs.get("is_test", 0):
+    # from version 7, force to use test mode
+    if cls.SINCE_VERSION >= 7 or node.attrs.get("is_test", 0):
       inputs = [x, running_mean, running_variance, bias, scale]
       return [cls.make_tensor_from_onnx_node(node, inputs=inputs)]
     spatial = node.attrs.get("spatial", 1) == 1

--- a/onnx_tf/handlers/backend/batch_normalization.py
+++ b/onnx_tf/handlers/backend/batch_normalization.py
@@ -1,6 +1,5 @@
 import tensorflow as tf
 
-from onnx_tf.common import is_test
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
@@ -39,8 +38,8 @@ class BatchNormalization(BackendHandler):
     running_variance = tf.reshape(tensor_dict[node.inputs[4]],
                                   params_shape_broadcast)
 
-    # force to use test mode since v7 with CI test
-    if node.attrs.get("is_test", 0) or (cls.SINCE_VERSION >= 7 and is_test()):
+    # from version 7, force to use test mode
+    if cls.SINCE_VERSION >= 7 or node.attrs.get("is_test", 0):
       inputs = [x, running_mean, running_variance, bias, scale]
       return [cls.make_tensor_from_onnx_node(node, inputs=inputs)]
     spatial = node.attrs.get("spatial", 1) == 1

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -127,16 +127,13 @@ class TestNode(unittest.TestCase):
         "BatchNormalization", ["X", "scale", "bias", "mean", "var"], ["Y"],
         epsilon=0.001)
     x_shape = [3, 5, 4, 2]
-    momentum = 0.9
     param_shape = [5]
     _param_shape = [1, 5, 1, 1]
     x = self._get_rnd(x_shape, 0, 1)
     m = self._get_rnd(param_shape, 0, 1)
     _m = m.reshape(_param_shape)
-    _m = _m * momentum + np.mean(x, axis=0) * (1 - momentum)
     v = self._get_rnd(param_shape, 0, 1)
     _v = v.reshape(_param_shape)
-    _v = _v * momentum + np.var(x, axis=0) * (1 - momentum)
     scale = self._get_rnd(param_shape, 0, 1)
     _scale = scale.reshape(_param_shape)
     bias = self._get_rnd(param_shape, 0, 1)


### PR DESCRIPTION
As they changed the specification of bn from v7, the test mode is always used in bn.

~~I am not sure with if `"PYTEST_CURRENT_TEST" in os.environ` is OK for local test~~
