### PR TITLE
Change onnx-tf behavior regarding a corner case ONNX spec does not address

### DIFF
--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -14,7 +14,6 @@ except ImportError:  # will be 3.x series
 
 from onnx import defs
 from onnx import numpy_helper
-from onnx import checker
 from onnx.backend.base import Backend
 from onnx.backend.base import Device
 from onnx.backend.base import namedtupledict


### PR DESCRIPTION
c.f. https://github.com/onnx/onnx/issues/1403, https://github.com/onnx/onnx-tensorflow/issues/244

This PR deals with an unspecified behavior in ONNX spec.
The motivation for this fix is that it allows our users to go through the tutorial smoothly; the tutorial happens to use a very outdated onnx model that reveals the loophole in the spec.

Basically, when ir_version < 3, opset_import is not specified, which means we automatically import the highest opset_version, causing breakage to outdated models. ONNX spec does not specify behaviors of backend in such situations, but friends from the spec repository suggest defaulting opset_import to 1 is a good idea.