### PR TITLE
Fix python3 issue and disconnected nodes

### DIFF
--- a/onnx_tf/handlers/frontend/bias_add.py
+++ b/onnx_tf/handlers/frontend/bias_add.py
@@ -14,21 +14,24 @@ class BiasAdd(ArithmeticMixin, FrontendHandler):
   @classmethod
   def version_1(cls, node, **kwargs):
     data_format = node.attr.get("data_format", "NHWC")
-    channel_first = data_format[1] == "C"
+    channel_first = chr(data_format[1]) == "C" if isinstance(
+        data_format[1], int) else data_format[1] == "C"
     axis = 1 if channel_first else -1
     return cls.arithmetic_op(node, axis=axis, **kwargs)
 
   @classmethod
   def version_6(cls, node, **kwargs):
     data_format = node.attr.get("data_format", "NHWC")
-    channel_first = data_format[1] == "C"
+    channel_first = chr(data_format[1]) == "C" if isinstance(
+        data_format[1], int) else data_format[1] == "C"
     axis = 1 if channel_first else -1
     return cls.arithmetic_op(node, axis=axis, **kwargs)
 
   @classmethod
   def version_7(cls, node, **kwargs):
     data_format = node.attr.get("data_format", "NHWC")
-    channel_first = data_format[1] == "C"
+    channel_first = chr(data_format[1]) == "C" if isinstance(
+        data_format[1], int) else data_format[1] == "C"
     axis = 1 if channel_first else -1
 
     unsqueeze_suffix = get_unique_suffix()
@@ -44,7 +47,7 @@ class BiasAdd(ArithmeticMixin, FrontendHandler):
           name=node.inputs[1] + unsqueeze_suffix)
       node_update_input = copy.deepcopy(node)
       node_update_input.inputs = [
-          node.inputs[0], node.inputs[1] + unsqueeze_suffix
+          node.inputs[0], node.inputs[1] + "_" + unsqueeze_suffix
       ]
       return [reshape_node, cls.arithmetic_op(node_update_input, **kwargs)]
     else:

--- a/test/frontend/test_node.py
+++ b/test/frontend/test_node.py
@@ -148,7 +148,9 @@ test_cases = [
 ("test_unpack", tf.unstack, "unstack", [get_rnd([2, 3, 4])], {}),
 ("test_xor", tf.logical_xor, "LogicalXor", [get_rnd([10, 10], dtype=np.bool_), get_rnd([10, 10], dtype=np.bool_)], {}),
 ("test_transpose", tf.transpose, "transpose", [get_rnd([2, 10])], {"perm":[1, 0]}),
-("test_concat", tf.concat, "concat", [[get_rnd([1, 10]),get_rnd([10, 10]),get_rnd([20, 10])], 0], {})
+("test_concat", tf.concat, "concat", [[get_rnd([1, 10]),get_rnd([10, 10]),get_rnd([20, 10])], 0], {}),
+("test_bias_add_nchw", tf.nn.bias_add, "BiasAdd", [get_rnd([10, 32, 10, 10]),get_rnd([32])], {"data_format":"NCHW"}),
+("test_bias_add_nhwc", tf.nn.bias_add, "BiasAdd", [get_rnd([10, 10, 10, 32]),get_rnd([32])], {"data_format":"NHWC"}),
 ]
 
 if not legacy_opset_pre_6():


### PR DESCRIPTION
In bias_add, the channel first check doesn't work in
python3, and inputs outputs name mismatch causes
disconnected nodes in graph. Add type check for
data_format[1] and underscore for inputs.