### PR TITLE
Updated readme to contain warning for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Because users often have their own preferences for which variant of Tensorflow t
 
 ## To test:
 For backend, run `python -m unittest discover test`.
+Warning: This will download several large neural networks and may take several minutes.
 
 ## Example:
 In this example, we will define and run a Relu node and print the result.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Because users often have their own preferences for which variant of Tensorflow t
 
 ## To test:
 For backend, run `python -m unittest discover test`.
-Warning: This will download several large neural networks and may take several minutes.
+Testing requires significant resources ..., but nonetheless, we highly recommend that users run through the complete test suite before deploying onnx-tf. The complete test suite typically takes between 15 and 45 minutes, depending on hardware configurations.
 
 ## Example:
 In this example, we will define and run a Relu node and print the result.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Because users often have their own preferences for which variant of Tensorflow t
 
 ## To test:
 For backend, run `python -m unittest discover test`.
-Testing requires significant resources ..., but nonetheless, we highly recommend that users run through the complete test suite before deploying onnx-tf. The complete test suite typically takes between 15 and 45 minutes, depending on hardware configurations.
+Testing requires significant hardware resources, but nonetheless, we highly recommend that users run through the complete test suite before deploying onnx-tf. The complete test suite typically takes between 15 and 45 minutes, depending on hardware configurations.
 
 ## Example:
 In this example, we will define and run a Relu node and print the result.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install the latest version of ONNX-TF via pip, run `pip install onnx-tf`.
 Because users often have their own preferences for which variant of Tensorflow to install (i.e., a GPU version instead of a CPU version), we do not explicitly require tensorflow in the installation script. It is therefore users' responsibility to ensure that the proper variant of Tensorflow is available to ONNX-TF. Moreoever, we require Tensorflow version >= 1.5.0.
 
 ## To test:
-For backend, run `python -m unittest discover test`.
+To perfom unit tests, run `python -m unittest discover test`.
 Testing requires significant hardware resources, but nonetheless, we highly recommend that users run through the complete test suite before deploying onnx-tf. The complete test suite typically takes between 15 and 45 minutes to complete, depending on hardware configurations.
 
 ## Example:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Because users often have their own preferences for which variant of Tensorflow t
 
 ## To test:
 For backend, run `python -m unittest discover test`.
-Testing requires significant hardware resources, but nonetheless, we highly recommend that users run through the complete test suite before deploying onnx-tf. The complete test suite typically takes between 15 and 45 minutes, depending on hardware configurations.
+Testing requires significant hardware resources, but nonetheless, we highly recommend that users run through the complete test suite before deploying onnx-tf. The complete test suite typically takes between 15 and 45 minutes to complete, depending on hardware configurations.
 
 ## Example:
 In this example, we will define and run a Relu node and print the result.


### PR DESCRIPTION
On my (relatively standard) desktop, the test suite takes 938 seconds, and downloads several very large neural networks. There should be a warning here for this for obvious reasons including hard disk space and network connectivity. Feel free to reject or modify the PR to make the warning more explicit. Thanks!