### PR TITLE
Fix check cli

### DIFF
--- a/onnx_tf/common/handler_helper.py
+++ b/onnx_tf/common/handler_helper.py
@@ -79,8 +79,10 @@ def get_all_backend_handlers(opset_dict):
 def get_frontend_coverage():
   """ Get frontend coverage for document.
 
-  :return: onnx_coverage: e.g. {'domain': {'ONNX_OP': [versions], ...}, ...}
+  :return: dict of frontend coverages
+  onnx_coverage: e.g. {'domain': {'ONNX_OP': [versions], ...}, ...}
   tf_coverage: e.g. {'domain': {'TF_OP': [versions], ...}, ...}
+  experimental_op: e.g. {'ONNX_OP'...}
   """
 
   tf_coverage = {}
@@ -97,7 +99,10 @@ def get_frontend_coverage():
       if getattr(handler, "EXPERIMENTAL", False):
         experimental_op.add(handler.ONNX_OP)
       _update_coverage(onnx_coverage, domain, onnx_op, versions)
-  return onnx_coverage, tf_coverage, experimental_op
+  return dict(
+      onnx_coverage=onnx_coverage,
+      tf_coverage=tf_coverage,
+      experimental_op=experimental_op)
 
 
 def get_backend_coverage():

--- a/onnx_tf/gen_opset.py
+++ b/onnx_tf/gen_opset.py
@@ -23,11 +23,15 @@ def main():
 
   backend_onnx_coverage = get_backend_coverage()
   backend_opset_dict.update(backend_onnx_coverage.get(defs.ONNX_DOMAIN, {}))
-  frontend_onnx_coverage, frontend_tf_coverage, experimental_op = get_frontend_coverage()
+  frontend_coverages = get_frontend_coverage()
+  frontend_onnx_coverage = frontend_coverages.get('onnx_coverage')
+  frontend_tf_coverage = frontend_coverages.get('tf_coverage')
+  experimental_op = frontend_coverages.get('experimental_op')
   frontend_opset_dict.update(frontend_onnx_coverage.get(defs.ONNX_DOMAIN, {}))
 
   for exp_op in experimental_op:
-    frontend_opset_dict["{} [EXPERIMENTAL]".format(exp_op)] = frontend_opset_dict.pop(exp_op)
+    frontend_opset_dict["{} [EXPERIMENTAL]".format(
+        exp_op)] = frontend_opset_dict.pop(exp_op)
 
   with open('opset_version.py', 'w') as version_file:
     pp = pprint.PrettyPrinter(indent=4)

--- a/onnx_tf/opr_checker.py
+++ b/onnx_tf/opr_checker.py
@@ -2,6 +2,7 @@ import argparse
 import warnings
 import logging
 import os
+from imp import reload
 
 from google.protobuf import text_format
 from onnx import defs
@@ -13,6 +14,7 @@ from onnx_tf.common.handler_helper import get_frontend_coverage
 from onnx_tf.pb_wrapper import TensorflowNode
 
 warnings.filterwarnings('ignore')
+reload(logging)
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
@@ -52,7 +54,7 @@ def check_opr_support(graph_def):
   logger.info('There are %s unique operators in the model file.',
               str(len(node_dict)))
 
-  frontend_coverage, frontend_tf_coverage = get_frontend_coverage()
+  frontend_tf_coverage = get_frontend_coverage().get('tf_coverage')
   frontend_tf_opset_dict = frontend_tf_coverage.get(defs.ONNX_DOMAIN, {})
   for k in node_dict:
     if k not in frontend_tf_opset_dict:


### PR DESCRIPTION
The graph check cli is broken with the addition of
experimental ops returned from get_frontend_coverage.
Also fixed the logging not working issue because of
earlier logging level set to warning.