### PR TITLE
Add frontend and backend support for Where

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -37,7 +37,7 @@ ______
 |DepthToSpace|1|
 |Div|1, 6, 7|
 |Dropout|1, 6, 7|
-|DynamicSlice|1|
+|DynamicSlice [EXPERIMENTAL]|1|
 |Elu|1, 6|
 |Equal|1, 7|
 |Erf|9|
@@ -139,7 +139,7 @@ ______
 |Transpose|1|
 |Unsqueeze|1|
 |Upsample|7, 9|
-|Where|N/A|
+|Where|9|
 |Xor|1, 7|
 
 

--- a/onnx_tf/handlers/backend/where.py
+++ b/onnx_tf/handlers/backend/where.py
@@ -1,0 +1,14 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+from onnx_tf.handlers.handler import tf_func
+
+
+@onnx_op("Where")
+@tf_func(tf.where)
+class Where(BackendHandler):
+
+  @classmethod
+  def version_9(cls, node, **kwargs):
+    return [cls.make_tensor_from_onnx_node(node, **kwargs)]

--- a/onnx_tf/handlers/frontend/select.py
+++ b/onnx_tf/handlers/frontend/select.py
@@ -1,0 +1,12 @@
+from onnx_tf.handlers.frontend_handler import FrontendHandler
+from onnx_tf.handlers.handler import onnx_op
+from onnx_tf.handlers.handler import tf_op
+
+
+@onnx_op("Where")
+@tf_op("Select")
+class Select(FrontendHandler):
+
+  @classmethod
+  def version_9(cls, node, **kwargs):
+    return cls.make_node_from_tf_node(node)

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -30,7 +30,7 @@ backend_opset_version = {
     'DepthToSpace': [1],
     'Div': [1, 6, 7],
     'Dropout': [1, 6, 7],
-    'DynamicSlice [EXPERIMENTAL]': [1],
+    'DynamicSlice': [1],
     'Elu': [1, 6],
     'Equal': [1, 7],
     'Erf': [9],
@@ -132,7 +132,7 @@ backend_opset_version = {
     'Transpose': [1],
     'Unsqueeze': [1],
     'Upsample': [7, 9],
-    'Where': [],
+    'Where': [9],
     'Xor': [1, 7]
 }
 
@@ -269,7 +269,7 @@ frontend_opset_version = {
     'Transpose': [1],
     'Unsqueeze': [1],
     'Upsample': [9],
-    'Where': [],
+    'Where': [9],
     'Xor': [1, 7]
 }
 
@@ -342,6 +342,7 @@ frontend_tf_opset_version = {
     'Reshape': [1, 5],
     'ResizeBilinear': [9],
     'Rsqrt': [1],
+    'Select': [9],
     'Selu': [1, 6],
     'Shape': [1],
     'Sigmoid': [1, 6],

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -254,6 +254,10 @@ class TestNode(unittest.TestCase):
     np.testing.assert_almost_equal(output["Y"].flatten(), values)
 
   def test_constant_fill(self):
+    if not legacy_opset_pre_ver(9):
+      raise unittest.SkipTest(
+          "ONNX version {} doesn't support ConstantFill.".format(
+              defs.onnx_opset_version()))
     shape = [1, 2, 3, 4]
     extra_shape = [5, 6]
     value = 3.
@@ -998,6 +1002,17 @@ class TestNode(unittest.TestCase):
     output = run_node(node_def, [x])
     np.testing.assert_almost_equal(output["Y"], np.transpose(x, (0, 2, 1)))
 
+  def test_where(self):
+    if legacy_opset_pre_ver(9):
+      raise unittest.SkipTest(
+          "ONNX version {} doesn't support Where.".format(
+              defs.onnx_opset_version()))
+    node_def = helper.make_node("Where", ["C","X","Y"], ["Z"])
+    c = np.array([[1, 0], [1, 1]], dtype=np.bool)
+    x = np.array([[1, 2], [3, 4]], dtype=np.float32)
+    y = np.array([[9, 8], [7, 6]], dtype=np.float32)
+    output = run_node(node_def, [c,x,y])
+    np.testing.assert_almost_equal(output["Z"], np.where(c,x,y))
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/frontend/test_node.py
+++ b/test/frontend/test_node.py
@@ -186,6 +186,8 @@ if not legacy_opset_pre_ver(9):
   test_cases.append(("test_is_nan", tf.is_nan, "IsNan", [[[1.0, 3.0, 5.0], [6.0, np.nan, 0.0], [np.nan, 11.0, 12.0]]], {}))
   test_cases.append(("test_sign", tf.sign, "Sign", [get_rnd([10, 10], -10, 10)], {}))
   test_cases.append(("test_erf", tf.erf, "Erf", [get_rnd([2, 3, 8])], {}))
+  test_cases.append(("test_select", tf.where, "Select", [np.array([[1, 0], [1, 1]], dtype=np.bool), get_rnd([2, 2]), get_rnd([2, 2])], {}))
+  test_cases.remove(("test_constant_fill", tf.fill, "Fill", [[1, 2, 3], 1], {}))
 
 # yapf: enable
 


### PR DESCRIPTION
Add frontend and backend support for Where operator which was
introduced in ONNX opset version 9.

Also filter out ConstantFill test cases since the operator
is removed from ONNX.