### PR TITLE
Add backend support for Shrink

### DIFF
--- a/onnx_tf/handlers/backend/shrink.py
+++ b/onnx_tf/handlers/backend/shrink.py
@@ -1,0 +1,36 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+
+
+@onnx_op("Shrink")
+class Shrink(BackendHandler):
+
+  @classmethod
+  def version_9(cls, node, **kwargs):
+    tensor_dict = kwargs["tensor_dict"]
+    input_tensor = tensor_dict[node.inputs[0]]
+    input_shape = tf.shape(input_tensor, out_type=tf.int64)
+
+    # handle defaults for attributes
+    lambd = node.attrs["lambd"] if "lambd" in node.attrs else 0.5
+    bias = node.attrs["bias"] if "bias" in node.attrs else 0.0
+
+    # make tensors in the right shape
+    lambd_tensor = tf.fill(input_shape, tf.constant(lambd, input_tensor.dtype))
+    lambd_neg_tensor = tf.fill(input_shape,
+                               tf.constant(lambd * -1, input_tensor.dtype))
+    bias_tensor = tf.fill(input_shape, tf.constant(bias, input_tensor.dtype))
+    zeros_tensor = tf.zeros(input_shape, input_tensor.dtype)
+
+    # prepare return values and conditions
+    input_plus = tf.add(input_tensor, bias_tensor)
+    input_minus = tf.subtract(input_tensor, bias_tensor)
+    greater_cond = tf.greater(input_tensor, lambd_tensor)
+    less_cond = tf.less(input_tensor, lambd_neg_tensor)
+
+    return [
+        tf.where(less_cond, input_plus,
+                 tf.where(greater_cond, input_minus, zeros_tensor))
+    ]

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -107,7 +107,7 @@ backend_opset_version = {
     'Scatter': [],
     'Selu': [1, 6],
     'Shape': [1],
-    'Shrink': [],
+    'Shrink': [9],
     'Sigmoid': [1, 6],
     'Sign': [9],
     'Sin': [7],

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -863,6 +863,19 @@ class TestNode(unittest.TestCase):
     output = run_node(node_def, [x])
     np.testing.assert_allclose(output["Y"], np.shape(x))
 
+  def test_shrink(self):
+    if legacy_opset_pre_ver(9):
+      raise unittest.SkipTest(
+          "ONNX version {} doesn't support Shrink.".format(
+              defs.onnx_opset_version()))
+
+    node_def = helper.make_node("Shrink", ["X"], ["Y"], bias=1.5, lambd=1.5)
+
+    X = np.arange(-2.0, 2.1, dtype=np.float32)
+    Y = np.array([-0.5, 0, 0, 0, 0.5], dtype=np.float32)
+    output = run_node(node_def, [X])
+    np.testing.assert_almost_equal(output["Y"], Y)
+
   def test_sigmoid(self):
     node_def = helper.make_node("Sigmoid", ["X"], ["Y"])
     x = self._get_rnd([1000])


### PR DESCRIPTION
Add backend support for Shrink which is introduced in
ONNX opset version 9.

There is no matching Tensorflow operator for shrink.
So the backend handler doesn't have tf.func decorator
and there is no frontend handler.