### PR TITLE
Fix the lstm issue with no initial_c

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -37,7 +37,7 @@ ______
 |DepthToSpace|1|
 |Div|1, 6, 7|
 |Dropout|1, 6, 7|
-|DynamicSlice [EXPERIMENTAL]|1|
+|DynamicSlice|1|
 |Elu|1, 6|
 |Equal|1, 7|
 |Erf|9|
@@ -114,7 +114,7 @@ ______
 |Scatter|N/A|
 |Selu|1, 6|
 |Shape|1|
-|Shrink|N/A|
+|Shrink|9|
 |Sigmoid|1, 6|
 |Sign|9|
 |Sin|7|
@@ -216,6 +216,7 @@ ______
 |Reshape|1, 5|
 |ResizeBilinear|9|
 |Rsqrt|1|
+|Select|9|
 |Selu|1, 6|
 |Shape|1|
 |Sigmoid|1, 6|

--- a/onnx_tf/handlers/backend/lstm.py
+++ b/onnx_tf/handlers/backend/lstm.py
@@ -156,14 +156,16 @@ class LSTM(RNNMixin, BackendHandler):
       cell_kwargs["num_units"] = hidden_size
       initial_state = None
       initial_state_bw = None
-      if input_size >= 7:
+      if input_size >= 6:
         initial_h = tensor_dict.get(node.inputs[5], None)
-        initial_c = tensor_dict.get(node.inputs[6], None)
+        initial_c = tensor_dict.get(
+            node.inputs[6],
+            None) if input_size >= 7 else tf.zeros_like(initial_h)
         if initial_h is not None and initial_c is not None:
           initial_state = (tf.nn.rnn_cell.LSTMStateTuple(
               initial_c[0], initial_h[0]),)
           if num_directions == 2:
-            initial_state_bw = initial_state = (tf.nn.rnn_cell.LSTMStateTuple(
+            initial_state_bw = (tf.nn.rnn_cell.LSTMStateTuple(
                 initial_c[1], initial_h[1]),)
 
       rnn_kwargs = {}


### PR DESCRIPTION
Fix the lstm issue with no initial_c, getting the
wrong result, as describled in issue:
https://github.com/onnx/onnx-tensorflow/issues/408
The solution is to set initial_c as zero when not provided
as an input, following onnx's assumption.