### PR TITLE
Add opset 10 support for dropout

### DIFF
--- a/.travis/onnx-master_tf-nightly/Dockerfile
+++ b/.travis/onnx-master_tf-nightly/Dockerfile
@@ -49,7 +49,7 @@ RUN cd /root/programs/onnx; pip2 install -e .
 RUN cd /root/programs/onnx; pip3 install -e .
 
 # Install Tensorflow
-RUN pip2 install -U tf-nightly
-RUN pip3 install -U tf-nightly
+RUN pip2 install -U tensorflow
+RUN pip3 install -U tensorflow
 
 WORKDIR /root/programs

--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -42,7 +42,7 @@ ______
 |DequantizeLinear|N/A|
 |DictVectorizer|N/A|
 |Div|1, 6, 7|
-|Dropout|1, 6, 7|
+|Dropout|1, 6, 7, 10|
 |Elu|1, 6|
 |Equal|1, 7, 11|
 |Erf|9|

--- a/onnx_tf/handlers/backend/dropout.py
+++ b/onnx_tf/handlers/backend/dropout.py
@@ -31,3 +31,7 @@ class Dropout(BackendHandler):
   @classmethod
   def version_7(cls, node, **kwargs):
     return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_10(cls, node, **kwargs):
+    return cls._common(node, **kwargs)

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -35,7 +35,7 @@ backend_opset_version = {
     'DequantizeLinear': [],
     'DictVectorizer': [],
     'Div': [1, 6, 7],
-    'Dropout': [1, 6, 7],
+    'Dropout': [1, 6, 7, 10],
     'Elu': [1, 6],
     'Equal': [1, 7, 11],
     'Erf': [9],

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -379,6 +379,20 @@ class TestNode(unittest.TestCase):
     output = run_node(node_def, [x, y])
     np.testing.assert_almost_equal(output["Z"], np.divide(x, y))
 
+  def test_dropout(self):
+    # Since current ONNX only support inference and
+    # dropout at inference mode is a no-op,
+    # therefore dropout is always a no-op operator
+    # in ONNX.
+    node_def = helper.make_node("Dropout", ["X"], ["Y"])
+    if legacy_opset_pre_ver(7):
+      # at inference mode, is_test is always set to 1
+      node_def = helper.make_node("Dropout", ["X"], ["Y"], is_test=1)
+    x = self._get_rnd([3, 4, 5])
+    y = x
+    output = run_node(node_def, [x])
+    np.testing.assert_equal(output["Y"], y)
+
   def test_dot(self):
     # this op is removed
     # remove this test in the future


### PR DESCRIPTION
Add opset 10 support for dropout and update CI environment to use TensorFlow stable release instead of nightly build