### PR TITLE
GRU support with linear_before_reset

### DIFF
--- a/onnx_tf/handlers/backend/rnn_mixin.py
+++ b/onnx_tf/handlers/backend/rnn_mixin.py
@@ -24,7 +24,8 @@ class RNNMixin(object):
 
   @classmethod
   def rnn(cls, x, cell_class, cell_kwargs, rnn_kwargs, activations, direction):
-    cell_kwargs["activation"] = activations[0]
+    if cell_class is not tf.contrib.cudnn_rnn.CudnnCompatibleGRUCell:
+      cell_kwargs["activation"] = activations[0]
 
     rnn_cell = [cell_class(**cell_kwargs)]
     cell_fw = tf.nn.rnn_cell.MultiRNNCell(rnn_cell)


### PR DESCRIPTION
Similar to #227 but without adding the backend, use the [CudnnCompatibleGRUCell](https://www.tensorflow.org/api_docs/python/tf/contrib/cudnn_rnn/CudnnCompatibleGRUCell) implementation in TensorFlow instead.