### PR TITLE
Update CI to use proper python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os:
   - linux
 #  - osx
-dist: trusty
+dist: xenial
 sudo: required
 language: python
 services:
@@ -17,4 +17,5 @@ before_install:
 
 script:
   - cd .. && docker cp onnx-tensorflow test:/root/programs/
-  - docker exec -e TRAVIS=1 -t test /bin/bash -c "cd onnx-tensorflow && pip install -e . && python -m unittest discover test"
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then docker exec -e TRAVIS=1 -t test /bin/bash -c "cd onnx-tensorflow && pip install -e . && python -m unittest discover test"; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then docker exec -e TRAVIS=1 -t test /bin/bash -c "cd onnx-tensorflow && pip3 install -e . && python3 -m unittest discover test"; fi

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,15 +1,5 @@
 export TRAVIS=1
 
-# Check if head has a tag?
-git describe --exact-match --tags HEAD
-if [ $? -eq 0 ]; then
-	echo "This is a release test for onnx-tf."
-	export DOCKER_CONTAINER_NAME="$(git describe --exact-match --tags HEAD)"
-	echo "Docker container is determined to be ${DOCKER_CONTAINER_NAME}."
-	docker pull winnietsang/onnx-tensoflow:${DOCKER_CONTAINER_NAME}
-	docker run -t -d --name=test winnietsang/onnx-tensoflow:${DOCKER_CONTAINER_NAME} /bin/bash
-else
-	echo "This is a non-release test for onnx-tf."
-	docker build -t=test-image ./.travis/onnx-master_tf-nightly
-	docker run -t -d --name=test test-image /bin/bash
-fi
+echo "This is a CI test for onnx-tf master with latest onnx and tf."
+docker build -t=test-image ./.travis/onnx-master_tf-nightly
+docker run -t -d --name=test test-image /bin/bash

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -389,32 +389,6 @@ class TestNode(unittest.TestCase):
     output = run_node(node_def, [x, y])
     np.testing.assert_almost_equal(output["Z"], np.dot(x, y))
 
-  def test_dynamic_slice(self):
-    # This is an experimental op added in ONNX 1.4 and defined under
-    # opset version 1. The following "if" statement is use to
-    # maintain backward compatibility
-    if defs.onnx_opset_version() < 9:
-      raise unittest.SkipTest(
-          "ONNX version {} doesn't support DynamicSlice.".format(
-              defs.onnx_opset_version()))
-    axes = np.array([0, 1], dtype=np.long)
-    starts = np.array([1, 0], dtype=np.long)
-    ends = np.array([2, 3], dtype=np.long)
-    # test case 1 with normal inputs
-    node_def = helper.make_node(
-        'DynamicSlice', inputs=['x', 'starts', 'ends', 'axes'], outputs=['y'])
-    x = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.long)
-    y = x[1:2, 0:3]
-    output = run_node(node_def, inputs=[x, starts, ends, axes], outputs=[y])
-    np.testing.assert_almost_equal(output['y'], x[1:2, 0:3])
-    # test case 2 with negative, out-of-bound and default inputs
-    starts = np.array([0, 1], dtype=np.long)
-    ends = np.array([-1, 1000], dtype=np.long)
-    node_def = helper.make_node(
-        'DynamicSlice', inputs=['x', 'starts', 'ends'], outputs=['y'])
-    output = run_node(node_def, inputs=[x, starts, ends], outputs=[y])
-    np.testing.assert_almost_equal(output['y'], x[0:-1, 1:1000])
-
   def test_elu(self):
     node_def = helper.make_node("Elu", ["X"], ["Y"])
     x = self._get_rnd([100])


### PR DESCRIPTION
Made a few minor updates
1. add python version check to run different pythons in docker
2. change base OS to xenial
3. remove script for release tag so we simply run CI for master