### PR TITLE
Extend support for GatherND/ScatterND/ScatterElements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,6 @@ cache: pip
 
 jobs:
   include:
-    - name: master-test-py2.7
-      python: 2.7
-      before_install:
-        - source ./.travis/setup_onnx_master.sh
-      script:
-        - cd .. && docker cp onnx-tensorflow test:/root/programs/
-        - docker exec -e TRAVIS=1 -t test /bin/bash -c "cd onnx-tensorflow && pip install -e . && python -m unittest discover test"
-
     - name: master-test-py3.6
       python: 3.6
       before_install:
@@ -25,14 +17,6 @@ jobs:
       script:
         - cd .. && docker cp onnx-tensorflow test:/root/programs/
         - docker exec -e TRAVIS=1 -t test /bin/bash -c "cd onnx-tensorflow && pip3 install -e . && python3 -m unittest discover test"
-
-    - name: target-test-py2.7
-      python: 2.7
-      before_install:
-        - source ./.travis/setup_onnx_target.sh
-      script:
-        - cd .. && docker cp onnx-tensorflow test:/root/programs/
-        - docker exec -e TRAVIS=1 -t test /bin/bash -c "cd onnx-tensorflow && pip install -e . && python -m unittest discover test"
 
     - name: target-test-py3.6
       python: 3.6

--- a/.travis/onnx-master_tf-1.x-release/Dockerfile
+++ b/.travis/onnx-master_tf-1.x-release/Dockerfile
@@ -33,10 +33,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          python3 python3-pip python3-dev python3-setuptools && \
      rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip
-RUN apt remove -y python-pip
-RUN pip install wheel ipython==5.0 numpy scipy pyyaml pytest
-
 RUN pip3 install --upgrade pip
 RUN apt remove -y python3-pip
 RUN pip3 install wheel ipython==5.0 numpy scipy pyyaml pytest
@@ -45,11 +41,9 @@ RUN mkdir -p /root/programs
 
 # Install ONNX
 RUN git clone --recursive https://github.com/onnx/onnx.git /root/programs/onnx
-RUN cd /root/programs/onnx; pip2 install -e .
 RUN cd /root/programs/onnx; pip3 install -e .
 
 # Install Tensorflow
-RUN pip2 install -U tensorflow
-RUN pip3 install -U tensorflow
+RUN pip3 install -U tensorflow==1.15.0
 
 WORKDIR /root/programs

--- a/.travis/setup_onnx_master.sh
+++ b/.travis/setup_onnx_master.sh
@@ -1,5 +1,5 @@
 export TRAVIS=1
 
-echo "This is a CI test for onnx-tf master with latest onnx and tf stable release."
-docker build -t=test-image ./.travis/onnx-master_tf-release
+echo "This is a CI test for onnx-tf master with latest onnx and tf final 1.x release."
+docker build -t=test-image ./.travis/onnx-master_tf-1.x-release
 docker run -t -d --name=test test-image /bin/bash

--- a/.travis/setup_onnx_target.sh
+++ b/.travis/setup_onnx_target.sh
@@ -1,5 +1,5 @@
 export TRAVIS=1
 
-echo "This is a CI test for onnx-tf master with onnx 1.5.0 and tf 1.15.0 release."
-docker pull winnietsang/onnx-tensorflow:onnx1.5.0-tf1.15.0
-docker run -t -d --name=test winnietsang/onnx-tensorflow:onnx1.5.0-tf1.15.0 /bin/bash
+echo "This is a CI test for onnx-tf master with onnx 1.6.0 and tf 1.15.0 release."
+docker pull winnietsang/onnx-tensorflow:onnx1.6.0-tf1.15.0
+docker run -t -d --name=test winnietsang/onnx-tensorflow:onnx1.6.0-tf1.15.0 /bin/bash

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ The specific ONNX release version that we support in the master branch of ONNX-T
 
 To install the latest version of ONNX-TF via pip, run `pip install onnx-tf`.
 
-Because users often have their own preferences for which variant of Tensorflow to install (i.e., a GPU version instead of a CPU version), we do not explicitly require tensorflow in the installation script. It is therefore users' responsibility to ensure that the proper variant of Tensorflow is available to ONNX-TF. Moreoever, we require Tensorflow version >= 1.15.0.
+Because users often have their own preferences for which variant of Tensorflow to install (i.e., a GPU version instead of a CPU version), we do not explicitly require tensorflow in the installation script. It is therefore users' responsibility to ensure that the proper variant of Tensorflow is available to ONNX-TF. Moreoever, we require Tensorflow version == 1.15.0.
 
 ## Development:
 
 ### Coverage Status:
-[ONNX-Tensorflow Op Coverage Status](https://github.com/onnx/onnx-tensorflow/blob/master/doc/support_status.md)
+[ONNX-Tensorflow Op Coverage Status](https://github.com/onnx/onnx-tensorflow/blob/tf-1.x/doc/support_status.md)
 
 ### API:
-[ONNX-Tensorflow API](https://github.com/onnx/onnx-tensorflow/blob/master/doc/API.md)
+[ONNX-Tensorflow API](https://github.com/onnx/onnx-tensorflow/blob/tf-1.x/doc/API.md)
 
 ### Installation:
 - Install ONNX master branch from source.
-- Install Tensorflow >= 1.15.0.
+- Install Tensorflow 1.15.0. (For Tensorflow 2.0 support please refer [here](https://github.com/onnx/onnx-tensorflow/blob/master/README.md/).)
 - Run `git clone git@github.com:onnx/onnx-tensorflow.git && cd onnx-tensorflow`.
 - Run `pip install -e .`.
 
@@ -81,8 +81,8 @@ Testing requires significant hardware resources, but nonetheless, we highly reco
 
 PS. Please ensure your code is backward compatible with older version of ONNX. You can easily test it by running the following [docker container](https://hub.docker.com/r/winnietsang/onnx-tensorflow) with your code. If you don't have Docker installed yet, please follow this link to install [Docker](https://docs.docker.com/install/) on your environment.
 ```
-sudo docker pull winnietsang/onnx-tensorflow:onnx1.5.0-tf1.15.0
-sudo docker run -it --name=YOUR-CONTAINER-NAME winnietsang/onnx-tensorflow:onnx1.5.0-tf1.15.0 /bin/bash
+sudo docker pull winnietsang/onnx-tensorflow:onnx1.6.0-tf1.15.0
+sudo docker run -it --name=YOUR-CONTAINER-NAME winnietsang/onnx-tensorflow:onnx1.6.0-tf1.15.0 /bin/bash
 git clone https://github.com/YOUR-USERNAME/onnx-tensorflow.git
 cd onnx-tensorflow
 git checkout -b YOUR-BRANCH --track remotes/origin/YOUR-BRANCH

--- a/onnx_tf/handlers/backend/gather_and_scatter_mixin.py
+++ b/onnx_tf/handlers/backend/gather_and_scatter_mixin.py
@@ -1,0 +1,76 @@
+import tensorflow as tf
+
+from onnx_tf.common.tf_helper import tf_shape
+
+
+class GatherAndScatterMixin(object):
+
+  @classmethod
+  def chk_idx_out_of_bounds(cls, data, indices):
+    """ Check indices out of bounds for ScatterND and GatherND
+    In Tensorflow GPU version, if an out of bound index is found,
+    a 0 is stored in the corresponding output value for GatherND;
+    and the index is ignored for ScatterND/TensorScatterNDUpdate.
+    But ONNX spec state that it is an error if any index values
+    are out of bounds. Therefore the converter need to run this
+    function to verify all the indices are in bounds before send
+    it to Tensoflow. If out of bound is detected then the caller
+    of this function need to throw InvalidArgumentError exception.
+    """
+    data_shape = tf_shape(data)
+    indices_shape = tf_shape(indices)
+
+    def _chk_idx_out_of_bounds(i, result):
+      indices_i = tf.transpose(indices)[i]
+      limit_i = tf.cast(data_shape, indices.dtype)[i]
+      cond1 = tf.greater_equal(indices_i, tf.negative(limit_i))
+      cond2 = tf.less(indices_i, limit_i)
+      result = tf.reduce_all(tf.logical_and(cond1, cond2))
+      return i + 1, result
+
+    _, result = tf.while_loop(
+        lambda i, result: tf.logical_and(tf.less(i, indices_shape[-1]), result),
+        _chk_idx_out_of_bounds, [0, True])
+    return result
+
+  @classmethod
+  def chk_idx_out_of_bounds_along_axis(cls, data, axis, indices):
+    """ Check indices out of bounds for ScatterElement
+    In Tensorflow GPU version, if an out of bound index is found,
+    the index is ignored for ScatterND/TensorScatterNDUpdate.
+    But ONNX spec state that it is an error if any index values
+    are out of bounds. Therefore the converter need to run this
+    function to verify all the indices are in bounds along the
+    axis before send it to Tensoflow. If out of bound is detected
+    then the caller of this function need to throw
+    InvalidArgumentError exception.
+    """
+    data_shape = tf.cast(tf_shape(data), indices.dtype)
+    limit = data_shape[axis]
+    cond1 = tf.greater_equal(indices, tf.negative(limit))
+    cond2 = tf.less(indices, limit)
+    return tf.logical_and(cond1, cond2)
+
+  @classmethod
+  def process_neg_idx(cls, data, indices):
+    """ Convert all the negative indices to positive
+    GatherND and ScatterND/TensorScatterNDUpdate in Tensorflow
+    doesn't support negative indices. Therefore need to run this
+    function to convert all the negative indices to positive before
+    send it to Tensorflow.
+    """
+    data_shape = tf_shape(data)
+    indices_shape = tf_shape(indices)
+    max_i = tf.cast(data_shape[:indices_shape[-1]], indices.dtype)
+    return tf.math.floormod(tf.add(indices, max_i), max_i)
+
+  @classmethod
+  def process_neg_idx_along_axis(cls, data, axis, indices):
+    """ Convert all the negative indices to positive
+    ScatterND/TensorScatterNDUpdate in Tensorflow doesn't support
+    negative indices. Therefore need to run this function to convert
+    all the negative indices to positive before send it to Tensorflow.
+    """
+    data_shape = tf_shape(data)
+    max_i = tf.cast(data_shape[axis], indices.dtype)
+    return tf.math.floormod(tf.add(indices, max_i), max_i)

--- a/onnx_tf/handlers/backend/gather_nd.py
+++ b/onnx_tf/handlers/backend/gather_nd.py
@@ -1,13 +1,20 @@
 import tensorflow as tf
 
 from onnx_tf.handlers.backend_handler import BackendHandler
-from onnx_tf.handlers.handler import onnx_op, tf_func
+from onnx_tf.handlers.handler import onnx_op
+from .gather_and_scatter_mixin import GatherAndScatterMixin
 
 
 @onnx_op("GatherND")
-@tf_func(tf.gather_nd)
-class GatherND(BackendHandler):
+class GatherND(GatherAndScatterMixin, BackendHandler):
 
   @classmethod
   def version_11(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    data = kwargs["tensor_dict"][node.inputs[0]]
+    indices = kwargs["tensor_dict"][node.inputs[1]]
+
+    result = cls.chk_idx_out_of_bounds(data, indices)
+    msg = 'GatherND indices are out of bounds, please double check the indices and retry.'
+    with tf.control_dependencies([tf.compat.v1.assert_equal(result, True, message=msg)]):
+      indices = cls.process_neg_idx(data, indices)
+      return [tf.gather_nd(data, indices)]

--- a/onnx_tf/handlers/backend/scatter_elements.py
+++ b/onnx_tf/handlers/backend/scatter_elements.py
@@ -1,11 +1,13 @@
 import tensorflow as tf
 
+from onnx_tf.common.tf_helper import tf_shape
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
+from .gather_and_scatter_mixin import GatherAndScatterMixin
 
 
 @onnx_op("ScatterElements")
-class ScatterElements(BackendHandler):
+class ScatterElements(GatherAndScatterMixin, BackendHandler):
 
   @classmethod
   def version_11(cls, node, **kwargs):
@@ -14,39 +16,49 @@ class ScatterElements(BackendHandler):
     indices = kwargs["tensor_dict"][node.inputs[1]]
     updates = kwargs["tensor_dict"][node.inputs[2]]
 
-    # Calculate shape of the tensorflow version of indices tensor.
-    sparsified_dense_idx_shape = updates.get_shape().as_list()
+    # poocess negative axis
+    axis = axis if axis >= 0 else tf.add(tf.rank(data), axis)
 
-    # Move on to convert ONNX indices to tensorflow indices in 2 steps:
-    #
-    # Step 1:
-    #   What would the index tensors look like if updates are all
-    #   dense? In other words, produce a coordinate tensor for updates:
-    #
-    #   coordinate[i, j, k ...] = [i, j, k ...]
-    #   where the shape of "coordinate" tensor is same as that of updates.
-    #
-    # Step 2:
-    #   But the coordinate tensor needs some correction because coord
-    #   vector at position axis is wrong (since we assumed update is dense,
-    #   but it is not at the axis specified).
-    #   So we update coordinate vector tensor elements at psotion=axis with
-    #   the sparse coordinate indices.
+    # check are there any indices are out of bounds
+    result = cls.chk_idx_out_of_bounds_along_axis(data, axis, indices)
+    msg = 'ScatterElements indices are out of bounds, please double check the indices and retry.'
+    with tf.control_dependencies([tf.compat.v1.assert_equal(result, True, message=msg)]):
+      # process negative indices
+      indices = cls.process_neg_idx_along_axis(data, axis, indices)
 
-    idx_tensors_per_axis = tf.meshgrid(*list(
-        map(lambda x: tf.range(x, dtype=tf.dtypes.int64),
-            sparsified_dense_idx_shape)),
-                                       indexing='ij')
-    idx_tensors_per_axis[axis] = indices
-    dim_expanded_idx_tensors_per_axis = list(
-        map(lambda x: tf.expand_dims(x, axis=-1), idx_tensors_per_axis))
-    coordinate = tf.concat(dim_expanded_idx_tensors_per_axis, axis=-1)
+      # Calculate shape of the tensorflow version of indices tensor.
+      sparsified_dense_idx_shape = tf_shape(updates)
 
-    # Now the coordinate tensor is in the shape
-    # [updates.shape, updates.rank]
-    # we need it to flattened into the shape:
-    # [product(updates.shape), updates.rank]
-    indices = tf.reshape(coordinate, [-1, tf.rank(data)])
-    updates = tf.reshape(updates, [-1])
+      # Move on to convert ONNX indices to tensorflow indices in 2 steps:
+      #
+      # Step 1:
+      #   What would the index tensors look like if updates are all
+      #   dense? In other words, produce a coordinate tensor for updates:
+      #
+      #   coordinate[i, j, k ...] = [i, j, k ...]
+      #   where the shape of "coordinate" tensor is same as that of updates.
+      #
+      # Step 2:
+      #   But the coordinate tensor needs some correction because coord
+      #   vector at position axis is wrong (since we assumed update is dense,
+      #   but it is not at the axis specified).
+      #   So we update coordinate vector tensor elements at psotion=axis with
+      #   the sparse coordinate indices.
 
-    return [tf.tensor_scatter_nd_update(data, indices, updates)]
+      idx_tensors_per_axis = tf.meshgrid(*list(
+          map(lambda x: tf.range(x, dtype=tf.dtypes.int64),
+              sparsified_dense_idx_shape)),
+                                         indexing='ij')
+      idx_tensors_per_axis[axis] = indices
+      dim_expanded_idx_tensors_per_axis = list(
+          map(lambda x: tf.expand_dims(x, axis=-1), idx_tensors_per_axis))
+      coordinate = tf.concat(dim_expanded_idx_tensors_per_axis, axis=-1)
+
+      # Now the coordinate tensor is in the shape
+      # [updates.shape, updates.rank]
+      # we need it to flattened into the shape:
+      # [product(updates.shape), updates.rank]
+      indices = tf.reshape(coordinate, [-1, tf.rank(data)])
+      updates = tf.reshape(updates, [-1])
+
+      return [tf.tensor_scatter_nd_update(data, indices, updates)]

--- a/onnx_tf/handlers/backend/scatter_nd.py
+++ b/onnx_tf/handlers/backend/scatter_nd.py
@@ -1,13 +1,20 @@
 import tensorflow as tf
 
 from onnx_tf.handlers.backend_handler import BackendHandler
-from onnx_tf.handlers.handler import onnx_op, tf_func
+from onnx_tf.handlers.handler import onnx_op
+from .gather_and_scatter_mixin import GatherAndScatterMixin
 
 
 @onnx_op("ScatterND")
-@tf_func(tf.tensor_scatter_nd_update)
-class ScatterND(BackendHandler):
+class ScatterND(GatherAndScatterMixin, BackendHandler):
 
   @classmethod
   def version_11(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    data = kwargs["tensor_dict"][node.inputs[0]]
+    indices = kwargs["tensor_dict"][node.inputs[1]]
+    updates = kwargs["tensor_dict"][node.inputs[2]]
+
+    result = cls.chk_idx_out_of_bounds(data, indices)
+    msg = 'ScatterND indices are out of bounds, please double check the indices and retry.'
+    with tf.control_dependencies([tf.compat.v1.assert_equal(result, True, message=msg)]):
+      return [tf.tensor_scatter_nd_update(data, cls.process_neg_idx(data, indices), updates)]

--- a/onnx_tf/handlers/backend/slice.py
+++ b/onnx_tf/handlers/backend/slice.py
@@ -59,9 +59,9 @@ class Slice(BackendHandler):
     axes = tensor_dict[node.inputs[3]] if len(
         node.inputs) >= 4 else tf.constant(l, ends.dtype)
 
-    axes = tf.map_fn(lambda axis: tf.where(
-        axis < 0, tf.add(tf.cast(tf.rank(
-            input_tensor), axis.dtype), axis), axis), axes)
+    # process negative axes
+    input_rank = tf.cast(tf.rank(input_tensor), axes.dtype)
+    axes = tf.math.floormod(tf.add(axes, input_rank), input_rank)
 
     # expand a dimension of 1 at the end
     sparse_indices = tf.expand_dims(axes, -1)

--- a/test/backend/test_onnx_backend.py
+++ b/test/backend/test_onnx_backend.py
@@ -20,11 +20,13 @@ def get_onnxtf_supported_ops():
   return opset_version.backend_opset_version
 
 def get_onnx_supported_ops():
-  onnx_opset_dict = {}
+  onnx_ops_dict = {}
   for schema in defs.get_all_schemas():
-    op = schema.name
-    onnx_opset_dict[op] = schema.since_version
-  return onnx_opset_dict
+    onnx_ops_dict[schema.name] = {
+        'version': schema.since_version,
+        'deprecated': schema.deprecated
+    }
+  return onnx_ops_dict
 
 def skip_not_implemented_ops_test(test):
   onnxtf_ops_list = get_onnxtf_supported_ops()
@@ -38,13 +40,14 @@ def skip_not_implemented_ops_test(test):
         i += 2
       else:
         i += 1
-    if op in onnxtf_ops_list:
-      if onnx_ops_list[op] not in onnxtf_ops_list[op]:
-        test.exclude(r'[a-z,_]*' + op.lower() + '[a-z,_]*')
-        test.exclude(r'[a-z,_]*' + op_name.lower() + '[a-z,_]*')
-    else:
-      test.exclude(r'[a-z,_]*' + op.lower() + '[a-z,_]*')
-      test.exclude(r'[a-z,_]*' + op_name.lower() + '[a-z,_]*')
+    if not onnx_ops_list[op]['deprecated']:
+      if op in onnxtf_ops_list:
+        if onnx_ops_list[op]['version'] not in onnxtf_ops_list[op]:
+          test.exclude(r'[a-z,_]*_' + op.lower() + '_[a-z,_]*')
+          test.exclude(r'[a-z,_]*_' + op_name.lower() + '_[a-z,_]*')
+      else:
+        test.exclude(r'[a-z,_]*_' + op.lower() + '_[a-z,_]*')
+        test.exclude(r'[a-z,_]*_' + op_name.lower() + '_[a-z,_]*')
   return test
 
 # This is a pytest magic variable to load extra plugins


### PR DESCRIPTION
Add support for negative indices and check indices out of bounds in GatherND, ScatterND and ScatterElements
Change the implementation of negative support of axes in Slice 
Improve the rule for skipping some ONNX backend test temporary in test_onnx_backend.py
Update README.md to reflect this README file is only for tf-1.x