### PR TITLE
Extend support for GatherND/ScatterND/ScatterElements

### DIFF
--- a/onnx_tf/handlers/backend/gather_and_scatter_mixin.py
+++ b/onnx_tf/handlers/backend/gather_and_scatter_mixin.py
@@ -1,0 +1,76 @@
+import tensorflow as tf
+
+from onnx_tf.common.tf_helper import tf_shape
+
+
+class GatherAndScatterMixin(object):
+
+  @classmethod
+  def chk_idx_out_of_bounds(cls, data, indices):
+    """ Check indices out of bounds for ScatterND and GatherND
+    In Tensorflow GPU version, if an out of bound index is found,
+    a 0 is stored in the corresponding output value for GatherND;
+    and the index is ignored for ScatterND/TensorScatterNDUpdate.
+    But ONNX spec state that it is an error if any index values
+    are out of bounds. Therefore the converter need to run this
+    function to verify all the indices are in bounds before send
+    it to Tensoflow. If out of bound is detected then the caller
+    of this function need to throw InvalidArgumentError exception.
+    """
+    data_shape = tf_shape(data)
+    indices_shape = tf_shape(indices)
+
+    def _chk_idx_out_of_bounds(i, result):
+      indices_i = tf.transpose(indices)[i]
+      limit_i = tf.cast(data_shape, indices.dtype)[i]
+      cond1 = tf.greater_equal(indices_i, tf.negative(limit_i))
+      cond2 = tf.less(indices_i, limit_i)
+      result = tf.reduce_all(tf.logical_and(cond1, cond2))
+      return i + 1, result
+
+    _, result = tf.while_loop(
+        lambda i, result: tf.logical_and(tf.less(i, indices_shape[-1]), result),
+        _chk_idx_out_of_bounds, [0, True])
+    return result
+
+  @classmethod
+  def chk_idx_out_of_bounds_along_axis(cls, data, axis, indices):
+    """ Check indices out of bounds for ScatterElement
+    In Tensorflow GPU version, if an out of bound index is found,
+    the index is ignored for ScatterND/TensorScatterNDUpdate.
+    But ONNX spec state that it is an error if any index values
+    are out of bounds. Therefore the converter need to run this
+    function to verify all the indices are in bounds along the
+    axis before send it to Tensoflow. If out of bound is detected
+    then the caller of this function need to throw
+    InvalidArgumentError exception.
+    """
+    data_shape = tf.cast(tf_shape(data), indices.dtype)
+    limit = data_shape[axis]
+    cond1 = tf.greater_equal(indices, tf.negative(limit))
+    cond2 = tf.less(indices, limit)
+    return tf.logical_and(cond1, cond2)
+
+  @classmethod
+  def process_neg_idx(cls, data, indices):
+    """ Convert all the negative indices to positive
+    GatherND and ScatterND/TensorScatterNDUpdate in Tensorflow
+    doesn't support negative indices. Therefore need to run this
+    function to convert all the negative indices to positive before
+    send it to Tensorflow.
+    """
+    data_shape = tf_shape(data)
+    indices_shape = tf_shape(indices)
+    max_i = tf.cast(data_shape[:indices_shape[-1]], indices.dtype)
+    return tf.math.floormod(tf.add(indices, max_i), max_i)
+
+  @classmethod
+  def process_neg_idx_along_axis(cls, data, axis, indices):
+    """ Convert all the negative indices to positive
+    ScatterND/TensorScatterNDUpdate in Tensorflow doesn't support
+    negative indices. Therefore need to run this function to convert
+    all the negative indices to positive before send it to Tensorflow.
+    """
+    data_shape = tf_shape(data)
+    max_i = tf.cast(data_shape[axis], indices.dtype)
+    return tf.math.floormod(tf.add(indices, max_i), max_i)

--- a/onnx_tf/handlers/backend/gather_nd.py
+++ b/onnx_tf/handlers/backend/gather_nd.py
@@ -1,13 +1,21 @@
 import tensorflow as tf
 
 from onnx_tf.handlers.backend_handler import BackendHandler
-from onnx_tf.handlers.handler import onnx_op, tf_func
+from onnx_tf.handlers.handler import onnx_op
+from .gather_and_scatter_mixin import GatherAndScatterMixin
 
 
 @onnx_op("GatherND")
-@tf_func(tf.gather_nd)
-class GatherND(BackendHandler):
+class GatherND(GatherAndScatterMixin, BackendHandler):
 
   @classmethod
   def version_11(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    data = kwargs["tensor_dict"][node.inputs[0]]
+    indices = kwargs["tensor_dict"][node.inputs[1]]
+
+    result = cls.chk_idx_out_of_bounds(data, indices)
+    msg = 'GatherND indices are out of bounds, please double check the indices and retry.'
+    with tf.control_dependencies(
+        [tf.compat.v1.assert_equal(result, True, message=msg)]):
+      indices = cls.process_neg_idx(data, indices)
+      return [tf.gather_nd(data, indices)]

--- a/onnx_tf/handlers/backend/scatter_elements.py
+++ b/onnx_tf/handlers/backend/scatter_elements.py
@@ -1,11 +1,13 @@
 import tensorflow as tf
 
+from onnx_tf.common.tf_helper import tf_shape
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
+from .gather_and_scatter_mixin import GatherAndScatterMixin
 
 
 @onnx_op("ScatterElements")
-class ScatterElements(BackendHandler):
+class ScatterElements(GatherAndScatterMixin, BackendHandler):
 
   @classmethod
   def version_11(cls, node, **kwargs):
@@ -14,40 +16,51 @@ class ScatterElements(BackendHandler):
     indices = kwargs["tensor_dict"][node.inputs[1]]
     updates = kwargs["tensor_dict"][node.inputs[2]]
 
-    # Calculate shape of the tensorflow version of indices tensor.
-    sparsified_dense_idx_shape = updates.get_shape().as_list()
+    # poocess negative axis
+    axis = axis if axis >= 0 else tf.add(tf.rank(data), axis)
 
-    # Move on to convert ONNX indices to tensorflow indices in 2 steps:
-    #
-    # Step 1:
-    #   What would the index tensors look like if updates are all
-    #   dense? In other words, produce a coordinate tensor for updates:
-    #
-    #   coordinate[i, j, k ...] = [i, j, k ...]
-    #   where the shape of "coordinate" tensor is same as that of updates.
-    #
-    # Step 2:
-    #   But the coordinate tensor needs some correction because coord
-    #   vector at position axis is wrong (since we assumed update is dense,
-    #   but it is not at the axis specified).
-    #   So we update coordinate vector tensor elements at psotion=axis with
-    #   the sparse coordinate indices.
+    # check are there any indices are out of bounds
+    result = cls.chk_idx_out_of_bounds_along_axis(data, axis, indices)
+    msg = 'ScatterElements indices are out of bounds, please double check the indices and retry.'
+    with tf.control_dependencies(
+        [tf.compat.v1.assert_equal(result, True, message=msg)]):
+      # process negative indices
+      indices = cls.process_neg_idx_along_axis(data, axis, indices)
 
-    idx_tensors_per_axis = tf.meshgrid(
-        *list(
-            map(lambda x: tf.range(x, dtype=tf.dtypes.int64),
-                sparsified_dense_idx_shape)),
-        indexing='ij')
-    idx_tensors_per_axis[axis] = indices
-    dim_expanded_idx_tensors_per_axis = list(
-        map(lambda x: tf.expand_dims(x, axis=-1), idx_tensors_per_axis))
-    coordinate = tf.concat(dim_expanded_idx_tensors_per_axis, axis=-1)
+      # Calculate shape of the tensorflow version of indices tensor.
+      sparsified_dense_idx_shape = tf_shape(updates)
 
-    # Now the coordinate tensor is in the shape
-    # [updates.shape, updates.rank]
-    # we need it to flattened into the shape:
-    # [product(updates.shape), updates.rank]
-    indices = tf.reshape(coordinate, [-1, tf.rank(data)])
-    updates = tf.reshape(updates, [-1])
+      # Move on to convert ONNX indices to tensorflow indices in 2 steps:
+      #
+      # Step 1:
+      #   What would the index tensors look like if updates are all
+      #   dense? In other words, produce a coordinate tensor for updates:
+      #
+      #   coordinate[i, j, k ...] = [i, j, k ...]
+      #   where the shape of "coordinate" tensor is same as that of updates.
+      #
+      # Step 2:
+      #   But the coordinate tensor needs some correction because coord
+      #   vector at position axis is wrong (since we assumed update is dense,
+      #   but it is not at the axis specified).
+      #   So we update coordinate vector tensor elements at psotion=axis with
+      #   the sparse coordinate indices.
 
-    return [tf.tensor_scatter_nd_update(data, indices, updates)]
+      idx_tensors_per_axis = tf.meshgrid(
+          *list(
+              map(lambda x: tf.range(x, dtype=tf.dtypes.int64),
+                  sparsified_dense_idx_shape)),
+          indexing='ij')
+      idx_tensors_per_axis[axis] = indices
+      dim_expanded_idx_tensors_per_axis = list(
+          map(lambda x: tf.expand_dims(x, axis=-1), idx_tensors_per_axis))
+      coordinate = tf.concat(dim_expanded_idx_tensors_per_axis, axis=-1)
+
+      # Now the coordinate tensor is in the shape
+      # [updates.shape, updates.rank]
+      # we need it to flattened into the shape:
+      # [product(updates.shape), updates.rank]
+      indices = tf.reshape(coordinate, [-1, tf.rank(data)])
+      updates = tf.reshape(updates, [-1])
+
+      return [tf.tensor_scatter_nd_update(data, indices, updates)]

--- a/onnx_tf/handlers/backend/scatter_nd.py
+++ b/onnx_tf/handlers/backend/scatter_nd.py
@@ -1,13 +1,24 @@
 import tensorflow as tf
 
 from onnx_tf.handlers.backend_handler import BackendHandler
-from onnx_tf.handlers.handler import onnx_op, tf_func
+from onnx_tf.handlers.handler import onnx_op
+from .gather_and_scatter_mixin import GatherAndScatterMixin
 
 
 @onnx_op("ScatterND")
-@tf_func(tf.tensor_scatter_nd_update)
-class ScatterND(BackendHandler):
+class ScatterND(GatherAndScatterMixin, BackendHandler):
 
   @classmethod
   def version_11(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    data = kwargs["tensor_dict"][node.inputs[0]]
+    indices = kwargs["tensor_dict"][node.inputs[1]]
+    updates = kwargs["tensor_dict"][node.inputs[2]]
+
+    result = cls.chk_idx_out_of_bounds(data, indices)
+    msg = 'ScatterND indices are out of bounds, please double check the indices and retry.'
+    with tf.control_dependencies(
+        [tf.compat.v1.assert_equal(result, True, message=msg)]):
+      return [
+          tf.tensor_scatter_nd_update(data, cls.process_neg_idx(data, indices),
+                                      updates)
+      ]

--- a/test/backend/test_onnx_backend.py
+++ b/test/backend/test_onnx_backend.py
@@ -20,11 +20,13 @@ def get_onnxtf_supported_ops():
   return opset_version.backend_opset_version
 
 def get_onnx_supported_ops():
-  onnx_opset_dict = {}
+  onnx_ops_dict = {}
   for schema in defs.get_all_schemas():
-    op = schema.name
-    onnx_opset_dict[op] = schema.since_version
-  return onnx_opset_dict
+    onnx_ops_dict[schema.name] = {
+        'version': schema.since_version,
+        'deprecated': schema.deprecated
+    }
+  return onnx_ops_dict
 
 def skip_not_implemented_ops_test(test):
   onnxtf_ops_list = get_onnxtf_supported_ops()
@@ -38,13 +40,14 @@ def skip_not_implemented_ops_test(test):
         i += 2
       else:
         i += 1
-    if op in onnxtf_ops_list:
-      if onnx_ops_list[op] not in onnxtf_ops_list[op]:
-        test.exclude(r'[a-z,_]*' + op.lower() + '[a-z,_]*')
-        test.exclude(r'[a-z,_]*' + op_name.lower() + '[a-z,_]*')
-    else:
-      test.exclude(r'[a-z,_]*' + op.lower() + '[a-z,_]*')
-      test.exclude(r'[a-z,_]*' + op_name.lower() + '[a-z,_]*')
+    if not onnx_ops_list[op]['deprecated']:
+      if op in onnxtf_ops_list:
+        if onnx_ops_list[op]['version'] not in onnxtf_ops_list[op]:
+          test.exclude(r'[a-z,_]*_' + op.lower() + '_[a-z,_]*')
+          test.exclude(r'[a-z,_]*_' + op_name.lower() + '_[a-z,_]*')
+      else:
+        test.exclude(r'[a-z,_]*_' + op.lower() + '_[a-z,_]*')
+        test.exclude(r'[a-z,_]*_' + op_name.lower() + '_[a-z,_]*')
   return test
 
 # This is a pytest magic variable to load extra plugins


### PR DESCRIPTION
Add support for negative indices and check indices out of bounds for
GatherND, ScatterND and ScatterElements

Improve the rule for skipping some ONNX backend test temporary in
test_onnx_backend.py