### PR TITLE
Add opset 11 support for Split

### DIFF
--- a/onnx_tf/handlers/backend/split.py
+++ b/onnx_tf/handlers/backend/split.py
@@ -15,7 +15,7 @@ class Split(BackendHandler):
   def args_check(cls, node, **kwargs):
     axis = node.attrs.get("axis", 0)
     x_rank =  len(kwargs["tensor_dict"][node.inputs[0]].get_shape().as_list())
-    if axis > x_rank -1 or axis < x_rank * -1:
+    if axis > x_rank - 1 or axis < -x_rank:
         raise ValueError("Axis is out of bound")
 
   @classmethod

--- a/onnx_tf/handlers/backend/split.py
+++ b/onnx_tf/handlers/backend/split.py
@@ -12,6 +12,13 @@ from onnx_tf.handlers.handler import tf_func
 class Split(BackendHandler):
 
   @classmethod
+  def args_check(cls, node, **kwargs):
+    axis = node.attrs.get("axis", 0)
+    x_rank =  len(kwargs["tensor_dict"][node.inputs[0]].get_shape().as_list())
+    if axis > x_rank -1 or axis < x_rank * -1:
+        raise ValueError("Axis is out of bound")
+
+  @classmethod
   def get_attrs_processor_param(cls):
     return {"default": {"axis": 0}}
 

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -2124,6 +2124,14 @@ class TestNode(unittest.TestCase):
     for a, b in zip(list(output), np.split(x, np.cumsum(split))[:-1]):
       np.testing.assert_almost_equal(a, b)
 
+    # test axis out of bound
+    node_def = helper.make_node("Split", ["X"],
+                                ["Z%i" % i for i in range(len(split))],
+                                axis=3,
+                                split=split)
+    with np.testing.assert_raises(ValueError):
+      output = run_node(node_def, [x])
+
   def test_sqrt(self):
     node_def = helper.make_node("Sqrt", ["X"], ["Y"])
     x = self._get_rnd_float32(shape=[1000]) + 1.0


### PR DESCRIPTION
Add opset 11 support for Split in checking the axis to be
inbound and providing a test case.