### PR TITLE
preserve names of initial tensor constants

### DIFF
--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -209,7 +209,8 @@ class TensorflowBackend(Backend):
              tf.constant(
                  tensor2list(init),
                  shape=init.dims,
-                 dtype=data_type.onnx2tf(init.data_type)))
+                 dtype=data_type.onnx2tf(init.data_type),
+                 name=init.name))
             for init in initializer]
 
   @classmethod


### PR DESCRIPTION
When a ONNX graph is converted, the initialization constant tensor names are not preserved in the target tensorflow model. Preserving constant names should improve quality of the converted model.

https://github.com/onnx/onnx-tensorflow/issues/545