### PR TITLE
tf-1.x: preserve names of initial tensor constants

### DIFF
--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -209,7 +209,8 @@ class TensorflowBackend(Backend):
              tf.constant(
                  tensor2list(init),
                  shape=init.dims,
-                 dtype=data_type.onnx2tf(init.data_type)))
+                 dtype=data_type.onnx2tf(init.data_type),
+                 name=init.name))
             for init in initializer]
 
   @classmethod


### PR DESCRIPTION
Apply the change in https://github.com/onnx/onnx-tensorflow/pull/544 to tf-1.x branch