### PR TITLE
Fix an expand issue with bool

### DIFF
--- a/onnx_tf/handlers/backend/expand.py
+++ b/onnx_tf/handlers/backend/expand.py
@@ -11,5 +11,12 @@ class Expand(BackendHandler):
   def version_8(cls, node, **kwargs):
     tensor_dict = kwargs["tensor_dict"]
     x, shape = tensor_dict[node.inputs[0]], tensor_dict[node.inputs[1]]
-    ones = tf.ones(shape, dtype=x.dtype)
-    return [x * ones]
+
+    # tf.math.multiply does not support bool therefore use int8
+    if x.dtype is tf.bool:
+      ones = tf.ones(shape, dtype=tf.int8)
+      r = tf.cast(x, tf.int8) * ones
+      return [tf.cast(r, tf.bool)]
+    else:
+      ones = tf.ones(shape, dtype=x.dtype)
+      return [x * ones]

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -668,6 +668,14 @@ class TestNode(unittest.TestCase):
     output = run_node(node_def, [x])
     np.testing.assert_almost_equal(output["Y"], np.exp(x))
 
+  def test_expand(self):
+    node_def = helper.make_node("Expand", ["X", "shape"], ["Y"])
+    x = [[True], [False], [True]]
+    shape = [2, 1, 6]
+    y = x * np.ones(shape, dtype=np.bool)
+    output = run_node(node_def, [x, shape])
+    np.testing.assert_almost_equal(output["Y"], y)
+
   def test_eye_like(self):
     if legacy_opset_pre_ver(9):
       raise unittest.SkipTest("ONNX version {} doesn't support EyeLike.".format(


### PR DESCRIPTION
If the input data type is bool, the expand operator would
fail to convert and throw an exception, as described in
https://github.com/onnx/onnx-tensorflow/issues/600

This PR converts input data to tf.int32 for matmul when
dtype is bool.