### PR TITLE
Undefined name from onnx_tf.common import exception

### DIFF
--- a/onnx_tf/handlers/backend/equal.py
+++ b/onnx_tf/handlers/backend/equal.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 
+from onnx_tf.common import exception
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func


### PR DESCRIPTION
`from onnx_tf.common import exception` for access to `exception.OP_UNSUPPORTED_EXCEPT` on line 29