### PR TITLE
Fix NonMaxSuppression handler

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,7 +1,7 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: ad918710664360e2422b4bdebc30e5b512a8794a )|
+|ONNX-Tensorflow Version|Master ( commit id: e3f8919ae1becfc16b3f522e89c52c47d9f6a6d8 )|
 |ONNX Version|Master ( commit id: 925b3657924c0c16cd20b54595f41e76159b03ab )|
 |Tensorflow Version|v2.2.0|
 
@@ -73,7 +73,7 @@ Notes:
 |HardSigmoid|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|
 |Hardmax|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|
 |Identity|**1**|1|1|1|1|1|1|1|1|1|1|1|**13**:small_red_triangle:|
-|If|**1**:small_red_triangle:|1:small_red_triangle:|1:small_red_triangle:|1:small_red_triangle:|1:small_red_triangle:|1:small_red_triangle:|1:small_red_triangle:|1:small_red_triangle:|1:small_red_triangle:|1:small_red_triangle:|**11**:small_red_triangle:|11:small_red_triangle:|11:small_red_triangle:|
+|If|**1**|1|1|1|1|1|1|1|1|1|**11**|11|11|
 |InstanceNormalization|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|
 |IsInf|-|-|-|-|-|-|-|-|-|**10**|10|10|10|
 |IsNaN|-|-|-|-|-|-|-|-|**9**|9|9|9|**13**:small_red_triangle:|
@@ -179,7 +179,7 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|9|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|
 
-ONNX-TF Supported Operators / ONNX Operators: 76 / 162
+ONNX-TF Supported Operators / ONNX Operators: 77 / 162
 
 Notes:
 1. Cast: Cast string to float32/float64/int32/int64 are not supported in Tensorflow.

--- a/onnx_tf/handlers/backend/non_max_suppression.py
+++ b/onnx_tf/handlers/backend/non_max_suppression.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 
+from onnx_tf.common.tf_helper import tf_shape
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 
@@ -16,15 +17,24 @@ class NonMaxSuppression(BackendHandler):
     # max_output_boxes for tf.image.non_max_suppression must be in tf.int32
     # therefore need to cast this input to tf.int32
     max_output_boxes_per_class = tf.cast(
-        tensor_dict['max_output_boxes_per_class'],
-        tf.int32) if 'max_output_boxes_per_class' in tensor_dict else tf.cast(
-            boxes.shape[1], tf.int32)
-    iou_threshold = tensor_dict[
-        'iou_threshold'] if 'iou_threshold' in tensor_dict else tf.constant(
-            [0.5], tf.float32)
-    score_threshold = tensor_dict[
-        'score_threshold'] if 'score_threshold' in tensor_dict else tf.constant(
-            [float('-inf')], tf.float32)
+        tensor_dict[node.inputs[2]],
+        tf.int32) if (len(node.inputs) > 2 and
+                      node.inputs[2] != "") else tf.constant(0, tf.int32)
+    # make sure max_output_boxes_per_class is a scalar not a 1-D 1 element tensor
+    max_output_boxes_per_class = tf.squeeze(max_output_boxes_per_class) if len(
+        max_output_boxes_per_class.shape) == 1 else max_output_boxes_per_class
+    iou_threshold = tensor_dict[node.inputs[3]] if (
+        len(node.inputs) > 3 and node.inputs[3] != "") else tf.constant(
+            0, tf.float32)
+    # make sure iou_threshold is a scalar not a 1-D 1 element tensor
+    iou_threshold = tf.squeeze(iou_threshold) if len(
+        iou_threshold.shape) == 1 else iou_threshold
+    score_threshold = tensor_dict[node.inputs[4]] if (
+        len(node.inputs) > 4 and node.inputs[4] != "") else tf.constant(
+            float('-inf'))
+    # make sure score_threshold is a scalar not a 1-D 1 element tensor
+    score_threshold = tf.squeeze(score_threshold) if len(
+        score_threshold.shape) == 1 else score_threshold
     center_point_box = node.attrs.get("center_point_box", 0)
 
     if center_point_box == 1:
@@ -44,21 +54,21 @@ class NonMaxSuppression(BackendHandler):
     def create_nodes(boxes, scores, max_output_boxes_per_class, iou_threshold,
                      score_threshold, result):
       # get number of batches in boxes
-      num_batches = tf.shape(boxes)[0]
+      num_batches = tf_shape(boxes)[0]
       for batch_i in tf.range(num_batches):
         # get boxes in batch_i only
         tf_boxes = tf.squeeze(tf.gather(boxes, [batch_i]), axis=0)
         # get scores of all classes in batch_i only
         batch_i_scores = tf.squeeze(tf.gather(scores, [batch_i]), axis=0)
         # get number of classess in batch_i only
-        num_classes = tf.shape(batch_i_scores)[0]
+        num_classes = tf_shape(batch_i_scores)[0]
         for class_j in tf.range(num_classes):
           # get scores in class_j for batch_i only
           tf_scores = tf.squeeze(tf.gather(batch_i_scores, [class_j]), axis=0)
           # get the selected boxes indices
           selected_indices = tf.image.non_max_suppression(
-              tf_boxes, tf_scores, max_output_boxes_per_class[0],
-              iou_threshold[0], score_threshold[0])
+              tf_boxes, tf_scores, max_output_boxes_per_class, iou_threshold,
+              score_threshold)
           # add batch and class information into the indices
           output = tf.transpose([tf.cast(selected_indices, dtype=tf.int64)])
           paddings = tf.constant([[0, 0], [1, 0]])


### PR DESCRIPTION
Input max_output_boxes_per_class, iou_threshold and score_threshold
should all be scalar, but the handler will accept 1-D 1 element tensor
as the value and squeeze out the extra dimension.
(The unit tests in ONNX backend test are using 1-D 1 element tensor for 
max_output_boxes_per_class, iou_threshold and score_threshold however, 
in model like Tiny YOLOv3 use scalar for those inputs.) 