### PR TITLE
Fix deprecated sparse_to_dense API

### DIFF
--- a/onnx_tf/handlers/backend/reshape.py
+++ b/onnx_tf/handlers/backend/reshape.py
@@ -22,20 +22,23 @@ class Reshape(BackendHandler):
 
     # Extract indicies of the shape parameter where
     # a copy from the original dimension size is needed.
-    copy_indices = tf.squeeze(
-        tf.where(tf.equal(shape, tf.constant(0, dtype=tf.int64))), -1)
+    sparse_indices = tf.where(tf.equal(shape, tf.constant(0, dtype=tf.int64)))
+    copy_indices = tf.squeeze(sparse_indices, -1)
 
     indices_gathered = tf.gather(input_shape, copy_indices)
-    indices_scattered = tf.compat.v1.sparse_to_dense(
-        copy_indices, tf.cast(tf.shape(shape), tf.int64), indices_gathered)
+    indices_scattered = tf.sparse.to_dense(
+        tf.sparse.SparseTensor(sparse_indices, indices_gathered,
+                               tf.cast(tf.shape(shape), tf.int64)))
 
     # Perform the copy wherever requested (wherever dim_size == 0)
     copied_shape = shape + indices_scattered
     attrs = copy.deepcopy(node.attrs)
     attrs.pop("shape", None)
     return [
-        cls.make_tensor_from_onnx_node(
-            node, inputs=[tensor, copied_shape], attrs=attrs, **kwargs)
+        cls.make_tensor_from_onnx_node(node,
+                                       inputs=[tensor, copied_shape],
+                                       attrs=attrs,
+                                       **kwargs)
     ]
 
   @classmethod

--- a/onnx_tf/handlers/backend/slice.py
+++ b/onnx_tf/handlers/backend/slice.py
@@ -24,8 +24,8 @@ class Slice(BackendHandler):
     axes = node.attrs.get("axes", list(range(slice_len)))
 
     for i in range(slice_len):
-      starts[i] = full_sizes[axes[i]] + starts[i] if starts[i] < 0 else starts[
-          i]
+      starts[i] = full_sizes[
+          axes[i]] + starts[i] if starts[i] < 0 else starts[i]
       ends[i] = full_sizes[axes[i]] + ends[i] if ends[i] < 0 else ends[i]
       if full_sizes[axes[i]] is not None:
         ends[i] = np.min([full_sizes[axes[i]], ends[i]])
@@ -34,15 +34,14 @@ class Slice(BackendHandler):
       full_sizes[axes[i]] = ends[i] - starts[i]
 
     return [
-        cls.make_tensor_from_onnx_node(
-            node,
-            tf_func=tf.slice,
-            inputs=[
-                tensor_dict[node.inputs[0]],
-                tf.constant(full_begin),
-                tf.constant(full_sizes)
-            ],
-            **kwargs)
+        cls.make_tensor_from_onnx_node(node,
+                                       tf_func=tf.slice,
+                                       inputs=[
+                                           tensor_dict[node.inputs[0]],
+                                           tf.constant(full_begin),
+                                           tf.constant(full_sizes)
+                                       ],
+                                       **kwargs)
     ]
 
   @classmethod
@@ -55,18 +54,19 @@ class Slice(BackendHandler):
     # first of all, get the input tensor shape
     input_tensor_shape = tf.shape(input_tensor, out_type=ends.dtype)
 
-    axes = tensor_dict[node.inputs[3]] if len(
-        node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends.dtype)
+    axes = tensor_dict[node.inputs[3]] if len(node.inputs) >= 4 else tf.range(
+        tf.shape(starts)[0], dtype=ends.dtype)
 
     is_axes_negative = tf.less(axes, tf.zeros_like(axes))
-    axes = tf.where(is_axes_negative, axes + tf.cast(tf.rank(input_tensor), axes.dtype), axes)
+    axes = tf.where(is_axes_negative,
+                    axes + tf.cast(tf.rank(input_tensor), axes.dtype), axes)
 
     # expand a dimension of 1 at the end
-    sparse_indices = tf.expand_dims(axes, -1)
+    sparse_indices = tf.cast(tf.expand_dims(axes, -1), tf.int64)
 
     # build the indexed dimension sizes as sparse_shape
-    sparse_shape = tf.gather_nd(
-        params=input_tensor_shape, indices=sparse_indices)
+    sparse_shape = tf.gather_nd(params=input_tensor_shape,
+                                indices=sparse_indices)
     sparse_shape = tf.cast(sparse_shape, ends.dtype)
 
     # take care of starts, ends that are larger than the dim size.
@@ -83,40 +83,40 @@ class Slice(BackendHandler):
     # need to densify everything for the inputs to slice
     # the output shape is the input_tensor rank
     output_shape = tf.reshape(tf.rank(input_tensor), [1])
-    output_shape = tf.cast(output_shape, ends.dtype)
+    output_shape = tf.cast(output_shape, tf.int64)
 
     # create dense tensor, pad 0 as default begins
-    dense_begins = tf.compat.v1.sparse_to_dense(sparse_indices, output_shape,
-                                                starts_final)
+    dense_begins = tf.sparse.to_dense(
+        tf.sparse.SparseTensor(sparse_indices, starts_final, output_shape))
+
     # create dense tensor, pad -1 for next step
-    dense_ends = tf.compat.v1.sparse_to_dense(
-        sparse_indices,
-        output_shape,
-        ends_final,
-        default_value=tf.constant(-1, dtype=dense_begins.dtype))
-    # replace -1 with respective dimension sizes
+    dense_ends = tf.sparse.SparseTensor(sparse_indices, ends_final,
+                                        output_shape)
+    dense_ends = tf.sparse.to_dense(dense_ends,
+                                    default_value=tf.constant(
+                                        -1, dtype=dense_begins.dtype))
     dense_ends = tf.where(
         tf.equal(dense_ends, tf.constant(-1, dtype=dense_begins.dtype)),
         input_tensor_shape, dense_ends)
 
     # create dense tensor for steps if not already so
     if len(node.inputs) >= 5:
-      dense_steps = tf.compat.v1.sparse_to_dense(
-          sparse_indices,
-          output_shape,
-          tensor_dict[node.inputs[4]],
+      dense_steps = tf.sparse.SparseTensor(sparse_indices,
+                                           tensor_dict[node.inputs[4]],
+                                           output_shape)
+      dense_steps = tf.sparse.to_dense(
+          dense_steps,
           default_value=tf.constant(1, dtype=tensor_dict[node.inputs[4]].dtype))
     else:
       dense_steps = tf.ones(input_tensor_shape.shape, ends.dtype)
 
     return [
-        cls.make_tensor_from_onnx_node(
-            node,
-            inputs=[
-                tensor_dict[node.inputs[0]], dense_begins, dense_ends,
-                dense_steps
-            ],
-            **kwargs)
+        cls.make_tensor_from_onnx_node(node,
+                                       inputs=[
+                                           tensor_dict[node.inputs[0]],
+                                           dense_begins, dense_ends, dense_steps
+                                       ],
+                                       **kwargs)
     ]
 
   @classmethod

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -282,9 +282,8 @@ class TestNode(unittest.TestCase):
       a = helper.make_sparse_tensor(values, indices, [3, 4])
       node_def = helper.make_node("Constant", [], ["Y"], sparse_value=a)
       output = run_node(node_def, [])
-      b = tf.compat.v1.sparse_to_dense(output["Y"].indices,
-                                       output["Y"].dense_shape,
-                                       output["Y"].values)
+      b = tf.sparse.SparseTensor(output["Y"].indices, output["Y"].values, output["Y"].dense_shape)
+      b = tf.sparse.to_dense(b)
       result = b.numpy()
       np.testing.assert_equal(result, expected)
 


### PR DESCRIPTION
This PR fixes the deprecated tf.compat.v1.sparse_to_dense API with
tf.sparse.SparseTensor and tf.sparse.to_dense