### PR TITLE
Added Opset 13 support for ArgMax and ArgMin

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,8 +1,7 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-
-|ONNX-Tensorflow Version|Master ( commit id: 4748f3ea8135057cccfc5e30c0f4339a913d4ebd )|
+|ONNX-Tensorflow Version|Master ( commit id: ee0e90567b9772fab4974607bcc64fe7d410865b )|
 |ONNX Version|Master ( commit id: cc2230603422bae893d5bc900d2d773ab34400a4 )|
 |Tensorflow Version|v2.2.0|
 
@@ -22,8 +21,8 @@ Notes:
 |Acosh|-|-|-|-|-|-|-|-|**9**|9|9|9|9|Acosh|
 |Add|**1**|1|1|1|1|**6**|**7**|7|7|7|7|7|**13**:small_red_triangle:|Add|
 |And|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|And|
-|ArgMax|**1**|1|1|1|1|1|1|1|1|1|**11**|**12**|**13**:small_red_triangle:|ArgMax|
-|ArgMin|**1**|1|1|1|1|1|1|1|1|1|**11**|**12**|**13**:small_red_triangle:|ArgMin|
+|ArgMax|**1**|1|1|1|1|1|1|1|1|1|**11**|**12**|**13**|ArgMax|
+|ArgMin|**1**|1|1|1|1|1|1|1|1|1|**11**|**12**|**13**|ArgMin|
 |Asin|-|-|-|-|-|-|**7**|7|7|7|7|7|7|Asin|
 |Asinh|-|-|-|-|-|-|-|-|**9**|9|9|9|9|Asinh|
 |Atan|-|-|-|-|-|-|**7**|7|7|7|7|7|7|Atan|
@@ -31,7 +30,7 @@ Notes:
 |AveragePool|**1**|1|1|1|1|1|**7**|7|7|**10**|**11**|11|11|AveragePool|
 |BatchNormalization|**1**|1|1|1|1|**6**|**7**|7|**9**|9|9|9|9|BatchNormalization|
 |BitShift|-|-|-|-|-|-|-|-|-|-|**11**|11|11|BitShift|
-|Cast|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**9**:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|**13**:small_red_triangle:|Cast|
+|Cast|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**9**:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|**13**:small_orange_diamond:|Cast|
 |Ceil|**1**|1|1|1|1|**6**|6|6|6|6|6|6|**13**:small_red_triangle:|Ceil|
 |Celu|-|-|-|-|-|-|-|-|-|-|-|**12**:small_red_triangle:|12:small_red_triangle:|Celu|
 |Clip|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**11**:small_orange_diamond:|**12**:small_orange_diamond:|**13**:small_orange_diamond:|Clip|
@@ -124,9 +123,9 @@ Notes:
 |ReduceL2|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|ReduceL2|
 |ReduceLogSum|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|ReduceLogSum|
 |ReduceLogSumExp|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|ReduceLogSumExp|
-|ReduceMax|**1**|1|1|1|1|1|1|1|1|1|**11**|**12**:small_red_triangle:|**13**:small_red_triangle:|ReduceMax|
+|ReduceMax|**1**|1|1|1|1|1|1|1|1|1|**11**|**12**|**13**:small_red_triangle:|ReduceMax|
 |ReduceMean|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|ReduceMean|
-|ReduceMin|**1**|1|1|1|1|1|1|1|1|1|**11**|**12**:small_red_triangle:|**13**:small_red_triangle:|ReduceMin|
+|ReduceMin|**1**|1|1|1|1|1|1|1|1|1|**11**|**12**|**13**:small_red_triangle:|ReduceMin|
 |ReduceProd|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|ReduceProd|
 |ReduceSum|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|ReduceSum|
 |ReduceSumSquare|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|ReduceSumSquare|
@@ -180,10 +179,10 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|9|Where|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|Xor|
 
-ONNX-TF Supported Operators / ONNX Operators: 80 / 162
+ONNX-TF Supported Operators / ONNX Operators: 83 / 162
 
 Notes:
-1. Cast: Cast string to float32/float64/int32/int64 are not supported in Tensorflow.
+1. Cast: Cast string to data types other than float32/float64/int32/int64 is not supported in Tensorflow
 2. Clip: Clip input in uint64 is not supported in Tensorflow.
 3. ConcatFromSequence: new_axis=1 not supported in Tensorflow.
 4. ConvTranspose: ConvTranspose with dilations != 1, or transposed convolution for 4D or higher are not supported in Tensorflow.

--- a/onnx_tf/common/data_type.py
+++ b/onnx_tf/common/data_type.py
@@ -39,6 +39,11 @@ def tf2onnx(dtype):
 
 
 def onnx2tf(dtype):
+  # The onnx2tf is done by going to a np type first. However,
+  # given that there is no bfloat16 in np at this time, we need
+  # to go directly to tf bfloat16 for now.
+  if dtype == int(TensorProto.BFLOAT16):
+    return tf.as_dtype("bfloat16")
   return tf.as_dtype(mapping.TENSOR_TYPE_TO_NP_TYPE[_onnx_dtype(dtype)])
 
 

--- a/onnx_tf/handlers/backend/arg_max.py
+++ b/onnx_tf/handlers/backend/arg_max.py
@@ -43,3 +43,7 @@ class ArgMax(BackendHandler):
   @classmethod
   def version_12(cls, node, **kwargs):
     return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
+    return cls._common(node, **kwargs)

--- a/onnx_tf/handlers/backend/arg_min.py
+++ b/onnx_tf/handlers/backend/arg_min.py
@@ -43,3 +43,7 @@ class ArgMin(BackendHandler):
   @classmethod
   def version_12(cls, node, **kwargs):
     return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
+    return cls._common(node, **kwargs)

--- a/onnx_tf/handlers/backend/cast.py
+++ b/onnx_tf/handlers/backend/cast.py
@@ -6,12 +6,12 @@ from onnx_tf.handlers.handler import tf_func
 from onnx_tf.handlers.handler import partial_support
 from onnx_tf.handlers.handler import ps_description
 
-
 @onnx_op("Cast")
 @tf_func(tf.cast)
 @partial_support(True)
-@ps_description("Cast string to float32/float64/int32/int64 " +
-                "are not supported in Tensorflow.")
+@ps_description("Cast string to data types other than " +
+                "float32/float64/int32/int64 is not supported in Tensorflow")
+
 class Cast(BackendHandler):
 
   @classmethod
@@ -19,15 +19,7 @@ class Cast(BackendHandler):
     return {"rename": {"to": "dtype"}}
 
   @classmethod
-  def version_1(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
-
-  @classmethod
-  def version_6(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
-
-  @classmethod
-  def version_9(cls, node, **kwargs):
+  def _common(cls, node, **kwargs):
     inp = kwargs["tensor_dict"][node.inputs[0]]
     to_type = node.attrs.get("to")
 
@@ -42,3 +34,20 @@ class Cast(BackendHandler):
       return [tf.strings.to_number(inp, to_type)]
 
     return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+
+  @classmethod
+  def version_1(cls, node, **kwargs):
+    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+
+  @classmethod
+  def version_6(cls, node, **kwargs):
+    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+
+  @classmethod
+  def version_9(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -6,8 +6,8 @@ backend_opset_version = {
     'Adam': [],
     'Add': [1, 6, 7],
     'And': [1, 7],
-    'ArgMax': [1, 11, 12],
-    'ArgMin': [1, 11, 12],
+    'ArgMax': [1, 11, 12, 13],
+    'ArgMin': [1, 11, 12, 13],
     'ArrayFeatureExtractor': [],
     'Asin': [7],
     'Asinh': [9],
@@ -17,7 +17,7 @@ backend_opset_version = {
     'BatchNormalization': [1, 6, 7, 9],
     'Binarizer': [],
     'BitShift': [11],
-    'Cast': [1, 6, 9],
+    'Cast': [1, 6, 9, 13],
     'CastMap': [],
     'CategoryMapper': [],
     'Ceil': [1, 6],
@@ -189,8 +189,8 @@ backend_opset_version = {
 }
 
 backend_partial_support = {
-    'Cast': 'Cast string to float32/float64/int32/int64 are not supported in '
-            'Tensorflow.',
+    'Cast': 'Cast string to data types other than float32/float64/int32/int64 '
+            'is not supported in Tensorflow',
     'Clip': 'Clip input in uint64 is not supported in Tensorflow.',
     'ConcatFromSequence': 'new_axis=1 not supported in Tensorflow.',
     'ConvTranspose': 'ConvTranspose with dilations != 1, or transposed '

--- a/test/backend/test_model.py
+++ b/test/backend/test_model.py
@@ -183,6 +183,42 @@ class TestModel(unittest.TestCase):
     output = tf_rep.run({"X": X})
     np.testing.assert_almost_equal(output.X1, Y_ref)
 
+  def test_argmax_node_bfloat(self):
+    X = np.random.randn(2, 8).astype(np.float32)
+    Y_ref = np.argmax(X, axis=0)
+
+    graph_def = helper.make_graph(
+        [
+            helper.make_node("Cast", ["X0"], ["X1"], to=TensorProto.BFLOAT16),
+            helper.make_node("ArgMax", ["X1"], ["X2"], axis=0, keepdims=0, select_last_index=0)
+        ],
+        name="test",
+        inputs=[helper.make_tensor_value_info("X0", TensorProto.FLOAT, [2, 8])],
+        outputs=[
+            helper.make_tensor_value_info("X2", TensorProto.BFLOAT16, [2, 8])
+        ])
+    tf_rep = prepare(helper.make_model(graph_def))
+    output = tf_rep.run({"X0": X})
+    np.testing.assert_almost_equal(output.X2, Y_ref)
+
+  def test_argmin_node_bfloat(self):
+    X = np.random.randn(2, 8).astype(np.float32)
+    Y_ref = np.argmin(X, axis=0)
+
+    graph_def = helper.make_graph(
+        [
+            helper.make_node("Cast", ["X0"], ["X1"], to=TensorProto.BFLOAT16),
+            helper.make_node("ArgMin", ["X1"], ["X2"], axis=0, keepdims=0, select_last_index=0)
+        ],
+        name="test",
+        inputs=[helper.make_tensor_value_info("X0", TensorProto.FLOAT, [2, 8])],
+        outputs=[
+            helper.make_tensor_value_info("X2", TensorProto.BFLOAT16, [2, 8])
+        ])
+    tf_rep = prepare(helper.make_model(graph_def))
+    output = tf_rep.run({"X0": X})
+    np.testing.assert_almost_equal(output.X2, Y_ref)
+
   def test_initializer(self):
     if legacy_onnx_pre_ver(1, 2):
       raise unittest.SkipTest(


### PR DESCRIPTION
The change in Opset 13 was a Type Constraint to support tensor(bfloat16). I have added test for this.