### PR TITLE
Fix initializer node name with leading underscore character

### DIFF
--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -211,6 +211,9 @@ class TensorflowBackend(Backend):
       return numpy_helper.to_array(onnx_tensor).flatten().tolist()
 
     def validate_initializer_name(name):
+      # Prepend a unique suffix if leading charater is "_"
+      name = get_unique_suffix() + name if name[0] is "_" else name
+
       # Replace ":" with "_tf_" and append a unique suffix for
       # traceability
       return name.replace(


### PR DESCRIPTION
Node name cannot start with an underscore character in Tensorflow.
This PR prepends a unique string to make it unique and valid.