### PR TITLE
Fix TF func call with duplicate arguments

### DIFF
--- a/onnx_tf/handlers/backend_handler.py
+++ b/onnx_tf/handlers/backend_handler.py
@@ -178,10 +178,11 @@ class BackendHandler(Handler):
         params = inspect.getargspec(tf_func).args
 
     attrs = cls._process_attrs(attrs)
+    attrs = {p: v for p, v in attrs.items() if p in params}
     kwargs = dict(zip(params, inputs))
     ambiguous_arguments = any(kwargs.get(p) is not None and v is not None
                               for p, v in attrs.items())
     if ambiguous_arguments:
       raise TypeError('Ambiguous arguments for {}()'.format(tf_func.__name__))
-    kwargs.update((p, v) for p, v in attrs.items() if p in params)
+    kwargs.update((p, v) for p, v in attrs.items() if v is not None)
     return tf_func(**kwargs)

--- a/onnx_tf/handlers/backend_handler.py
+++ b/onnx_tf/handlers/backend_handler.py
@@ -178,5 +178,10 @@ class BackendHandler(Handler):
         params = inspect.getargspec(tf_func).args
 
     attrs = cls._process_attrs(attrs)
-    return tf_func(*inputs,
-                   **dict([(p, attrs[p]) for p in params if p in attrs]))
+    kwargs = dict(zip(params, inputs))
+    ambiguous_arguments = any(kwargs.get(p) is not None and v is not None
+                              for p, v in attrs.items())
+    if ambiguous_arguments:
+      raise TypeError('Ambiguous arguments for {}()'.format(tf_func.__name__))
+    kwargs.update((p, v) for p, v in attrs.items() if p in params)
+    return tf_func(**kwargs)


### PR DESCRIPTION
Sometimes `inputs` passed to `BackendHandler._run_tf_func` may have so many elements that they intersect with given `attrs`. It causes errors like ones mentioned there: https://github.com/onnx/onnx-tensorflow/issues/499#issuecomment-623029133. I suggest to check such ambiguities and allow passing them if one of the passed values is `None`.