### PR TITLE
Fix ConvInteger optional inputs handle

### DIFF
--- a/onnx_tf/handlers/backend/conv_integer.py
+++ b/onnx_tf/handlers/backend/conv_integer.py
@@ -22,10 +22,10 @@ class ConvInteger(ConvMixin, BackendHandler):
 
     def process_conv(new_x, new_w):
       # Remove zero-points from inputs
-      if "x_zero_point" in node.inputs:
-        node.inputs.remove("x_zero_point")
-      if "w_zero_point" in node.inputs:
-        node.inputs.remove("w_zero_point")
+      if len(node.inputs) == 4:
+        node.inputs.remove(node.inputs[3])
+      if len(node.inputs) == 3:
+        node.inputs.remove(node.inputs[2])
 
       new_dict = {node.inputs[0]: new_x, node.inputs[1]: new_w}
 
@@ -35,13 +35,13 @@ class ConvInteger(ConvMixin, BackendHandler):
       return conv_node
 
     # Apply x_zero_point first
-    x = cls._apply_zero_point(x, tensor_dict[
-        "x_zero_point"]) if "x_zero_point" in node.inputs else tf.cast(
+    x = cls._apply_zero_point(
+        x, tensor_dict[node.inputs[2]]) if len(node.inputs) > 2 else tf.cast(
             x, tf.float32)
 
     # Apply w_zero_point next
-    if "w_zero_point" in node.inputs:
-      w_zero_point = tensor_dict["w_zero_point"]
+    if len(node.inputs) == 4:
+      w_zero_point = tensor_dict[node.inputs[3]]
       if w_zero_point.shape.rank == 0:
         # Simply apply w_zero_point for scalar
         w = cls._apply_zero_point(w, w_zero_point)

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -408,11 +408,13 @@ class TestNode(unittest.TestCase):
     w_zero_point = np.int8(1)
     y = np.array([16, 20, 28, 32]).astype(np.int32).reshape((1, 1, 2, 2))
 
-    node = helper.make_node("ConvInteger", ["X", "W", "w_zero_point"], ["Y"],
+    node = helper.make_node("ConvInteger",
+                            ["X", "W", "x_zero_point", "w_zero_point"],
+                            ["Y"],
                             kernel_shape=[2, 2],
                             pads=[0, 0, 0, 0],
                             dilations=[1, 1])
-    output = run_node(node, [x, w, w_zero_point])
+    output = run_node(node, [x, w, np.int8(0), w_zero_point])
     np.testing.assert_almost_equal(output["Y"], y)
 
     # Test x_zero_point and w_zero_point
@@ -424,7 +426,8 @@ class TestNode(unittest.TestCase):
     y = np.array([12, 16, 24, 28]).astype(np.int32).reshape((1, 1, 2, 2))
 
     node = helper.make_node("ConvInteger",
-                            ["X", "W", "x_zero_point", "w_zero_point"], ["Y"],
+                            ["X", "W", "x_zero_point", "w_zero_point"],
+                            ["Y"],
                             kernel_shape=[2, 2],
                             pads=[0, 0, 0, 0],
                             dilations=[1, 1])
@@ -438,11 +441,13 @@ class TestNode(unittest.TestCase):
     w_zero_point = np.array([1]).astype(np.int8)
     y = np.array([16, 20, 28, 32]).astype(np.int32).reshape((1, 1, 2, 2))
 
-    node = helper.make_node("ConvInteger", ["X", "W", "w_zero_point"], ["Y"],
+    node = helper.make_node("ConvInteger",
+                            ["X", "W", "x_zero_point", "w_zero_point"],
+                            ["Y"],
                             kernel_shape=[2, 2],
                             pads=[0, 0, 0, 0],
                             dilations=[1, 1])
-    output = run_node(node, [x, w, w_zero_point])
+    output = run_node(node, [x, w, np.int8(0), w_zero_point])
     np.testing.assert_almost_equal(output["Y"], y)
 
     # Test w_zero_point as 1d tensor shape 2
@@ -453,11 +458,13 @@ class TestNode(unittest.TestCase):
     y = np.array([12, 16, 24, 28, 0, 0, 0, 0]).astype(np.int32).reshape(
         (1, 2, 2, 2))
 
-    node = helper.make_node("ConvInteger", ["X", "W", "w_zero_point"], ["Y"],
+    node = helper.make_node("ConvInteger",
+                            ["X", "W", "x_zero_point", "w_zero_point"],
+                            ["Y"],
                             kernel_shape=[2, 2],
                             pads=[0, 0, 0, 0],
                             dilations=[1, 1])
-    output = run_node(node, [x, w, w_zero_point])
+    output = run_node(node, [x, w, np.int8(0), w_zero_point])
     np.testing.assert_almost_equal(output["Y"], y)
 
   def test_conv_transpose(self):


### PR DESCRIPTION
'x_zero_point' and 'w_zero_point' are both optional inputs, should check the number of inputs to decide whether the user have send in these optional inputs, and should get the value by the input position.