### PR TITLE
Add sequence ops support for opset 11 to tf-1.x

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,7 +1,7 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: d2228b9b6008a38965ff7d42776fb3438edaa734 )|
+|ONNX-Tensorflow Version|Master ( commit id: f4abdcc961658049693689bb281b7bb9c431eeaf )|
 |ONNX Version|Master ( commit id: 0c070abb0c40fec649f81a73a75b0098662ec486 )|
 |Tensorflow Version|v1.15.0|
 
@@ -33,7 +33,7 @@ Notes:
 |Cast|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**9**:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|
 |Ceil|**1**|1|1|1|1|**6**|6|6|6|6|6|6|
 |Celu|-|-|-|-|-|-|-|-|-|-|-|**12**:small_red_triangle:|
-|Clip|**1**|1|1|1|1|**6**|6|6|6|6|**11**|**12**:small_red_triangle:|
+|Clip|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**11**:small_orange_diamond:|**12**:small_orange_diamond:|
 |Compress|-|-|-|-|-|-|-|-|**9**|9|**11**|11|
 |Concat|**1**|1|1|**4**|4|4|4|4|4|4|**11**|11|
 |ConcatFromSequence|-|-|-|-|-|-|-|-|-|-|**11**:small_red_triangle:|11:small_red_triangle:|
@@ -50,7 +50,7 @@ Notes:
 |Det|-|-|-|-|-|-|-|-|-|-|**11**|11|
 |Div|**1**|1|1|1|1|**6**|**7**|7|7|7|7|7|
 |Dropout|**1**|1|1|1|1|**6**|**7**|7|7|**10**|10|**12**:small_red_triangle:|
-|DynamicQuantizeLinear|-|-|-|-|-|-|-|-|-|-|**11**:small_red_triangle:|11:small_red_triangle:|
+|DynamicQuantizeLinear|-|-|-|-|-|-|-|-|-|-|**11**|11|
 |Einsum|-|-|-|-|-|-|-|-|-|-|-|**12**:small_red_triangle:|
 |Elu|**1**|1|1|1|1|**6**|6|6|6|6|6|6|
 |Equal|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**7**:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|**11**:small_orange_diamond:|11:small_orange_diamond:|
@@ -62,7 +62,7 @@ Notes:
 |Floor|**1**|1|1|1|1|**6**|6|6|6|6|6|6|
 |GRU|**1**:small_orange_diamond:|1:small_orange_diamond:|**3**:small_orange_diamond:|3:small_orange_diamond:|3:small_orange_diamond:|3:small_orange_diamond:|**7**:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|
 |Gather|**1**|1|1|1|1|1|1|1|1|1|**11**|11|
-|GatherElements|-|-|-|-|-|-|-|-|-|-|**11**:small_red_triangle:|11:small_red_triangle:|
+|GatherElements|-|-|-|-|-|-|-|-|-|-|**11**|11|
 |GatherND|-|-|-|-|-|-|-|-|-|-|**11**|**12**:small_red_triangle:|
 |Gemm|**1**|1|1|1|1|**6**|**7**|7|**9**|9|**11**|11|
 |GlobalAveragePool|**1**|1|1|1|1|1|1|1|1|1|1|1|
@@ -86,7 +86,7 @@ Notes:
 |LogSoftmax|**1**|1|1|1|1|1|1|1|1|1|**11**|11|
 |Loop|**1**|1|1|1|1|1|1|1|1|1|**11**|11|
 |LpNormalization|**1**|1|1|1|1|1|1|1|1|1|1|1|
-|LpPool|**1**:small_red_triangle:|**2**:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|**11**:small_red_triangle:|11:small_red_triangle:|
+|LpPool|**1**|**2**|2|2|2|2|2|2|2|2|**11**|11|11|
 |MatMul|**1**|1|1|1|1|1|1|1|**9**|9|9|9|
 |MatMulInteger|-|-|-|-|-|-|-|-|-|**10**|10|10|
 |Max|**1**|1|1|1|1|**6**|6|**8**|8|8|8|**12**:small_red_triangle:|
@@ -131,7 +131,7 @@ Notes:
 |ReduceSumSquare|**1**|1|1|1|1|1|1|1|1|1|**11**|11|
 |Relu|**1**|1|1|1|1|**6**|6|6|6|6|6|6|
 |Reshape|**1**|1|1|1|**5**|5|5|5|5|5|5|5|
-|Resize|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|**11**:small_red_triangle:|11:small_red_triangle:|
+|Resize|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|**11**:small_orange_diamond:|11:small_orange_diamond:|
 |ReverseSequence|-|-|-|-|-|-|-|-|-|**10**|10|10|
 |RoiAlign|-|-|-|-|-|-|-|-|-|**10**:small_red_triangle:|10:small_red_triangle:|10:small_red_triangle:|
 |Round|-|-|-|-|-|-|-|-|-|-|**11**|11|
@@ -179,18 +179,31 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|
 
-ONNX-TF Supported Operators / ONNX Operators: 131 / 162
+ONNX-TF Supported Operators / ONNX Operators: 135 / 162
 
 Notes:
 1. Cast: Cast string to float32/float64/int32/int64 are not supported in Tensorflow.
-2. ConvTranspose: ConvTranspose with dilations != 1, or transposed convolution for 4D or higher are not supported in Tensorflow.
-3. CumSum: CumSum inputs in uint32/uint64 are not supported in Tensorflow.
-4. Equal: Equal inputs in uint16/uint32/uint64 are not supported in Tensorflow.
-5. GRU: GRU with clip or GRU with linear_before_reset, or GRU not using sigmoid for z and r, or GRU using Elu as the activation function with alpha != 1, or GRU using HardSigmoid as the activation function with alpha != 0.2 or beta != 0.5 are not supported in TensorFlow.
-6. LSTM: LSTM not using sigmoid for `f`, or LSTM not using the same activation for `g` and `h` are not supported in Tensorflow.
-7. MaxPool: MaxPoolWithArgmax with pad is None or incompatible mode, or MaxPoolWithArgmax with 4D or higher input, orMaxPoolWithArgmax with column major are not supported in Tensorflow.
-8. Mod: Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 are not supported in Tensorflow.
-9. OneHot: OneHot indices in uint16/uint32/uint64/int8/int16/float16/float/double, or OneHot depth in uint8/uint16/uint32/uint64/int8/int16/int64/float16/float/double are not supported in Tensorflow.
-10. RNN: RNN with clip is not supported in Tensorflow.
-11. Resize: Resize required 4D input in Tensorflow.
-12. Upsample: Upsample required 4D input in Tensorflow.
+2. Clip: Clip input in uint64 is not supported in Tensorflow.
+3. ConvTranspose: ConvTranspose with dilations != 1, or transposed convolution for 4D or higher are not supported in Tensorflow.
+4. CumSum: CumSum inputs in uint32/uint64 are not supported in Tensorflow.
+5. Equal: Equal inputs in uint16/uint32/uint64 are not supported in Tensorflow.
+6. GRU: GRU with clip or GRU with linear_before_reset, or GRU not using sigmoid for z and r, or GRU using Elu as the activation function with alpha != 1, or GRU using HardSigmoid as the activation function with alpha != 0.2 or beta != 0.5 are not supported in TensorFlow.
+7. LSTM: LSTM not using sigmoid for `f`, or LSTM not using the same activation for `g` and `h` are not supported in Tensorflow.
+8. MaxPool: MaxPoolWithArgmax with pad is None or incompatible mode, or MaxPoolWithArgmax with 4D or higher input, orMaxPoolWithArgmax with column major are not supported in Tensorflow.
+9. Mod: Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 are not supported in Tensorflow.
+10. OneHot: OneHot indices in uint16/uint32/uint64/int8/int16/float16/float/double, or OneHot depth in uint8/uint16/uint32/uint64/int8/int16/int64/float16/float/double are not supported in Tensorflow.
+11. RNN: RNN with clip is not supported in Tensorflow.
+12. Resize: Resize required 4D input in Tensorflow. For opset 11, only the following attributes and inputs conbination are supported in Tensorflow:
+	1. mode=nearest, coordinate_transformation_mode=align_corners, nearest_mode=round_prefer_ceil, can use scales(*) or sizes.
+	2. mode=nearest, coordinate_transformation_mode=asymmetric, nearest_mode=floor, can use scales(*) or sizes.
+	3. mode=nearest, coordinate_transformation_mode=tf_half_pixel_for_nn, nearest_mode=floor, can use scales(*) or sizes.
+	4. mode=linear, coordinate_transformation_mode=align_corners, can use scales(*) or sizes.
+	5. mode=linear, coordinate_transformation_mode=asymmetric, can use scales(*) or sizes.
+	6. mode=linear, coordinate_transformation_mode=half_pixel, can use scales(*) or sizes.
+	7. mode=cubic, coordinate_transformation_mode=align_corners, cubic_coeff_a=-0.5, exclude_outside=1, can use scales(*) or sizes.
+	8. mode=cubic, coordinate_transformation_mode=asymmetric, cubic_coeff_a=-0.5, exclude_outside=1, can use scales(*) or sizes.
+	9. mode=cubic, coordinate_transformation_mode=half_pixel, cubic_coeff_a=-0.5, exclude_outside=1, can use scales(*) or sizes.
+	10. mode=nearest, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, nearest_mode=round_prefer_ceil, can use scales or sizes.
+	11. mode=linear, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, can use scales or sizes.
+	- Note (*): The accuracy of your model will go down, if the height and the width of the new sizes(scales * origial sizes) are not in whole numbers.
+13. Upsample: Upsample required 4D input in Tensorflow.

--- a/onnx_tf/handlers/backend/sequence_at.py
+++ b/onnx_tf/handlers/backend/sequence_at.py
@@ -1,0 +1,45 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+
+
+@onnx_op("SequenceAt")
+class SequenceAt(BackendHandler):
+
+  @classmethod
+  def chk_pos_in_bounds(cls, input_seq, pos):
+    """
+    Check the position is in-bounds with respect to the sequence.
+    Accepted range for 'position' is in [-n, n - 1], where n is the
+    number of tensors in 'input_sequence'.
+
+    :param input_seq: input sequence
+    :param pos: position of the output tensor
+
+    :return: True if position is in-bounds or input length is dynamic.
+    """
+    seq_length = input_seq.shape[0].value
+    if seq_length is None:
+      return True
+
+    seq_length = tf.cast(seq_length, pos.dtype)
+
+    cond1 = tf.greater_equal(pos, tf.negative(seq_length))
+    cond2 = tf.less_equal(pos, seq_length - 1)
+
+    # pos >= -n and pos < n
+    return tf.reduce_all(tf.logical_and(cond1, cond2))
+
+  @classmethod
+  def version_11(cls, node, **kwargs):
+    tensor_dict = kwargs["tensor_dict"]
+    input_sequence = tensor_dict[node.inputs[0]]
+    position = tensor_dict[node.inputs[1]]
+
+    # check whether position is in-bounds and assert if not
+    result = cls.chk_pos_in_bounds(input_sequence, position)
+    assert_pos = tf.Assert(tf.equal(result, True), [result])
+
+    with tf.control_dependencies([assert_pos]):
+      return [input_sequence[position]]

--- a/onnx_tf/handlers/backend/sequence_construct.py
+++ b/onnx_tf/handlers/backend/sequence_construct.py
@@ -1,0 +1,26 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+
+
+@onnx_op("SequenceConstruct")
+class SequenceConstruct(BackendHandler):
+
+  @classmethod
+  def version_11(cls, node, **kwargs):
+    # create an empty sequence first
+    tensor_dict = kwargs["tensor_dict"]
+    dtype = tensor_dict[node.inputs[0]].dtype
+    input_sequence = tf.ragged.constant([], dtype=dtype)
+
+    # insert tensors at the end of sequence
+    for i in range(len(node.inputs)):
+      input_tensor = tf.expand_dims(tensor_dict[node.inputs[i]], 0)
+      if input_sequence.shape[0] == 0:
+        output_seq = tf.RaggedTensor.from_tensor(input_tensor)
+      else:
+        output_seq = tf.concat([input_sequence, input_tensor], axis=0)
+      input_sequence = output_seq
+
+    return [output_seq]

--- a/onnx_tf/handlers/backend/sequence_empty.py
+++ b/onnx_tf/handlers/backend/sequence_empty.py
@@ -1,0 +1,20 @@
+import numpy as np
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+from onnx_tf.common import data_type
+from onnx import mapping
+
+
+@onnx_op("SequenceEmpty")
+class SequenceEmpty(BackendHandler):
+
+  @classmethod
+  def version_11(cls, node, **kwargs):
+    default_dtype = mapping.NP_TYPE_TO_TENSOR_TYPE[np.dtype('float32')]
+    dtype = data_type.onnx2tf(node.attrs.get("dtype", default_dtype))
+
+    ragged = tf.RaggedTensor.from_row_lengths(values=[], row_lengths=[])
+    sparse = tf.cast(ragged.to_sparse(), dtype)
+    return [tf.RaggedTensor.from_sparse(sparse)]

--- a/onnx_tf/handlers/backend/sequence_erase.py
+++ b/onnx_tf/handlers/backend/sequence_erase.py
@@ -1,0 +1,45 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+
+
+@onnx_op("SequenceErase")
+class SequenceErase(BackendHandler):
+
+  @classmethod
+  def chk_pos_in_bounds(cls, input_seq, pos):
+    """
+    Check the position is in-bounds with respect to the sequence.
+    Accepted range for 'position' is in [-n, n - 1], where n is the
+    number of tensors in 'input_sequence'.
+
+    :param input_seq: input sequence
+    :param pos: position of the output tensor
+
+    :return: True if position is in-bounds 
+    """
+    seq_length = tf.shape(input_seq.to_sparse(), out_type=pos.dtype)[0]
+
+    cond1 = tf.greater_equal(pos, tf.negative(seq_length))
+    cond2 = tf.less_equal(pos, seq_length - 1)
+
+    # pos >= -n and pos < n
+    return tf.reduce_all(tf.logical_and(cond1, cond2))
+
+  @classmethod
+  def version_11(cls, node, **kwargs):
+    tensor_dict = kwargs["tensor_dict"]
+    input_sequence = tensor_dict[node.inputs[0]]
+    seq_length = tf.shape(input_sequence.to_sparse())[0]
+    position = tensor_dict[node.inputs[1]] if len(
+        node.inputs) == 2 else seq_length - 1
+
+    # check whether position is in-bounds and assert if not
+    result = cls.chk_pos_in_bounds(input_sequence, position)
+    assert_pos = tf.Assert(tf.equal(result, True), [result])
+
+    with tf.control_dependencies([assert_pos]):
+      s1 = input_sequence[:position]
+      s2 = input_sequence[position + 1:]
+      return [tf.concat([s1, s2], axis=0)]

--- a/onnx_tf/handlers/backend/sequence_insert.py
+++ b/onnx_tf/handlers/backend/sequence_insert.py
@@ -1,0 +1,52 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+
+
+@onnx_op("SequenceInsert")
+class SequenceInsert(BackendHandler):
+
+  @classmethod
+  def chk_pos_in_bounds(cls, input_seq, pos):
+    """ 
+    Check the position is in-bounds with respect to the sequence.
+    Accepted range for 'position' is in [-n, n], where n is the 
+    number of tensors in 'input_sequence'. 
+
+    :param input_seq: input sequence
+    :param pos: position to insert the tensor
+
+    :return: True if position is in-bounds.
+    """
+    seq_length = tf.shape(input_seq.to_sparse(), out_type=pos.dtype)[0]
+
+    cond1 = tf.greater_equal(pos, tf.negative(seq_length))
+    cond2 = tf.less_equal(pos, seq_length)
+
+    # pos >= -n and pos <= n
+    return tf.reduce_all(tf.logical_and(cond1, cond2))
+
+  @classmethod
+  def version_11(cls, node, **kwargs):
+    tensor_dict = kwargs["tensor_dict"]
+    input_sequence = tensor_dict[node.inputs[0]]
+    input_tensor = tensor_dict[node.inputs[1]]
+
+    position = tensor_dict[node.inputs[2]] if len(
+        node.inputs) > 2 else tf.shape(input_sequence.to_sparse())[0]
+
+    # check whether position is in-bounds and assert if not
+    result = cls.chk_pos_in_bounds(input_sequence, position)
+    assert_pos = tf.Assert(tf.equal(result, True), [result])
+
+    with tf.control_dependencies([assert_pos]):
+      input_tensor = tf.expand_dims(input_tensor, 0)
+      if input_sequence.shape[0] == 0:
+        output_seq = tf.RaggedTensor.from_tensor(input_tensor)
+      else:
+        s1 = input_sequence[:position]
+        s2 = input_sequence[position:]
+        output_seq = tf.concat([s1, input_tensor, s2], axis=0)
+
+      return [output_seq]

--- a/onnx_tf/handlers/backend/sequence_length.py
+++ b/onnx_tf/handlers/backend/sequence_length.py
@@ -1,0 +1,15 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+
+
+@onnx_op("SequenceLength")
+class SequenceLength(BackendHandler):
+
+  @classmethod
+  def version_11(cls, node, **kwargs):
+    tensor_dict = kwargs["tensor_dict"]
+    input_sequence = tensor_dict[node.inputs[0]]
+
+    return [tf.shape(input_sequence.to_sparse(), out_type=tf.int64)[0]]

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -22,7 +22,7 @@ backend_opset_version = {
     'CategoryMapper': [],
     'Ceil': [1, 6],
     'Celu': [],
-    'Clip': [1, 6, 11],
+    'Clip': [1, 6, 11, 12],
     'Compress': [9, 11],
     'Concat': [1, 4, 11],
     'ConcatFromSequence': [],
@@ -41,7 +41,7 @@ backend_opset_version = {
     'DictVectorizer': [],
     'Div': [1, 6, 7],
     'Dropout': [1, 6, 7, 10],
-    'DynamicQuantizeLinear': [],
+    'DynamicQuantizeLinear': [11],
     'Einsum': [],
     'Elu': [1, 6],
     'Equal': [1, 7, 11],
@@ -54,7 +54,7 @@ backend_opset_version = {
     'Floor': [1, 6],
     'GRU': [1, 3, 7],
     'Gather': [1, 11],
-    'GatherElements': [],
+    'GatherElements': [11],
     'GatherND': [11],
     'Gemm': [1, 6, 7, 9, 11],
     'GlobalAveragePool': [1],
@@ -85,11 +85,11 @@ backend_opset_version = {
     'LogSoftmax': [1, 11],
     'Loop': [1, 11],
     'LpNormalization': [1],
-    'LpPool': [],
+    'LpPool': [1, 2, 11],
     'MatMul': [1, 9],
     'MatMulInteger': [10],
     'Max': [1, 6, 8],
-    'MaxPool': [1, 8, 10, 11],
+    'MaxPool': [1, 8, 10, 11, 12],
     'MaxRoiPool': [],
     'MaxUnpool': [9, 11],
     'Mean': [1, 6, 8],
@@ -133,7 +133,7 @@ backend_opset_version = {
     'ReduceSumSquare': [1, 11],
     'Relu': [1, 6],
     'Reshape': [1, 5],
-    'Resize': [10],
+    'Resize': [10, 11],
     'ReverseSequence': [10],
     'RoiAlign': [],
     'Round': [11],
@@ -191,6 +191,7 @@ backend_opset_version = {
 backend_partial_support = {
     'Cast': 'Cast string to float32/float64/int32/int64 are not supported in '
             'Tensorflow.',
+    'Clip': 'Clip input in uint64 is not supported in Tensorflow.',
     'ConvTranspose': 'ConvTranspose with dilations != 1, or transposed '
                      'convolution for 4D or higher are not supported in '
                      'Tensorflow.',
@@ -215,6 +216,41 @@ backend_partial_support = {
               'uint8/uint16/uint32/uint64/int8/int16/int64/float16/float/double '
               'are not supported in Tensorflow.',
     'RNN': 'RNN with clip is not supported in Tensorflow.',
-    'Resize': 'Resize required 4D input in Tensorflow.',
+    'Resize': 'Resize required 4D input in Tensorflow. For opset 11, only the '
+              'following attributes and inputs conbination are supported in '
+              'Tensorflow:\n'
+              '\t1. mode=nearest, '
+              'coordinate_transformation_mode=align_corners, '
+              'nearest_mode=round_prefer_ceil, can use scales(*) or sizes.\n'
+              '\t2. mode=nearest, coordinate_transformation_mode=asymmetric, '
+              'nearest_mode=floor, can use scales(*) or sizes.\n'
+              '\t3. mode=nearest, '
+              'coordinate_transformation_mode=tf_half_pixel_for_nn, '
+              'nearest_mode=floor, can use scales(*) or sizes.\n'
+              '\t4. mode=linear, coordinate_transformation_mode=align_corners, '
+              'can use scales(*) or sizes.\n'
+              '\t5. mode=linear, coordinate_transformation_mode=asymmetric, '
+              'can use scales(*) or sizes.\n'
+              '\t6. mode=linear, coordinate_transformation_mode=half_pixel, '
+              'can use scales(*) or sizes.\n'
+              '\t7. mode=cubic, coordinate_transformation_mode=align_corners, '
+              'cubic_coeff_a=-0.5, exclude_outside=1, can use scales(*) or '
+              'sizes.\n'
+              '\t8. mode=cubic, coordinate_transformation_mode=asymmetric, '
+              'cubic_coeff_a=-0.5, exclude_outside=1, can use scales(*) or '
+              'sizes.\n'
+              '\t9. mode=cubic, coordinate_transformation_mode=half_pixel, '
+              'cubic_coeff_a=-0.5, exclude_outside=1, can use scales(*) or '
+              'sizes.\n'
+              '\t10. mode=nearest, '
+              'coordinate_transformation_mode=tf_crop_and_resize, '
+              'extrapolation_value=any_float_value, '
+              'nearest_mode=round_prefer_ceil, can use scales or sizes.\n'
+              '\t11. mode=linear, '
+              'coordinate_transformation_mode=tf_crop_and_resize, '
+              'extrapolation_value=any_float_value, can use scales or sizes.\n'
+              '\t- Note (*): The accuracy of your model will go down, if the '
+              'height and the width of the new sizes(scales * origial sizes) '
+              'are not in whole numbers.',
     'Upsample': 'Upsample required 4D input in Tensorflow.'
 }

--- a/test/backend/test_model.py
+++ b/test/backend/test_model.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import unittest
 
 import numpy as np
+import onnx
 from onnx_tf.backend import prepare
 from onnx import helper
 from onnx import TensorProto
@@ -21,6 +22,81 @@ class TestModel(unittest.TestCase):
     return np.random.uniform(low, high, np.prod(shape)) \
                       .reshape(shape) \
                       .astype(np.float32)
+
+  def test_sequence_ops(self):
+    # test SequenceConstruct and SequenceAt
+    a = np.random.randn(2, 1, 2).astype(np.float32)
+    b = np.random.randn(1, 1, 2).astype(np.float32)
+    c = np.random.randn(3, 1, 2).astype(np.float32)
+    seq_construct_node = helper.make_node('SequenceConstruct', ['a', 'b', 'c'], ['S'])
+    seq_at_node = helper.make_node('SequenceAt', ['S','at'], ['Y'])
+    out_value_info = helper.make_tensor_value_info('Y',onnx.TensorProto.FLOAT,[None])
+    a_value_info =  helper.make_tensor_value_info('a',onnx.TensorProto.FLOAT,[2, 1, 2])
+    b_value_info =  helper.make_tensor_value_info('b',onnx.TensorProto.FLOAT,[1, 1, 2])
+    c_value_info =  helper.make_tensor_value_info('c',onnx.TensorProto.FLOAT,[3, 1, 2])
+    at_value_info =  helper.make_tensor_value_info('at',onnx.TensorProto.INT32,[])
+
+    graph = helper.make_graph([seq_construct_node, seq_at_node],
+            name='seq_construct_at_test',
+            inputs=[a_value_info, b_value_info, c_value_info, at_value_info],
+            outputs=[out_value_info])
+    model = helper.make_model(graph, producer_name='backend-test')
+    tf_rep = prepare(model)
+    output = tf_rep.run({'a':a, 'b':b, 'c':c, 'at':0})
+    np.testing.assert_almost_equal(output["Y"], a)
+    output = tf_rep.run({'a':a, 'b':b, 'c':c, 'at':-2})
+    np.testing.assert_almost_equal(output["Y"], b)
+    output = tf_rep.run({'a':a, 'b':b, 'c':c, 'at':2})
+    np.testing.assert_almost_equal(output["Y"], c)
+
+    # test SequenceEmpty, SequenceInsert, and SequenceAt
+    p = np.int32(0)
+    seq_empty_node = helper.make_node('SequenceEmpty', [], ['S'])
+    seq_insert_node1 = helper.make_node('SequenceInsert', ['S','a'], ['S1'])
+    seq_insert_node2 = helper.make_node('SequenceInsert', ['S1','b'], ['S2'])
+    seq_insert_node3 = helper.make_node('SequenceInsert', ['S2','c','p'], ['S3'])
+    seq_at_node = helper.make_node('SequenceAt', ['S3','at'], ['Y'])
+
+    p_value_info = helper.make_tensor_value_info('p',onnx.TensorProto.INT32,[])
+
+    graph = helper.make_graph([seq_empty_node, seq_insert_node1, seq_insert_node2, seq_insert_node3, seq_at_node],
+            name='seq_empty_insert_at_test',
+            inputs=[a_value_info, b_value_info, c_value_info, p_value_info, at_value_info],
+            outputs=[out_value_info])
+    model = helper.make_model(graph, producer_name='backend-test')
+    tf_rep = prepare(model)
+    output = tf_rep.run({'a':a, 'b':b, 'c':c, 'p':p, 'at':0})
+    np.testing.assert_almost_equal(output["Y"], c)
+
+    # test SequenceConstruct, SequenceErase, and SequenceLength
+    seq_construct_node = helper.make_node('SequenceConstruct', ['a', 'b', 'c'], ['S'])
+    seq_erase_node = helper.make_node('SequenceErase', ['S','p'], ['S1'])
+    seq_length_node = helper.make_node('SequenceLength', ['S1'], ['Y'])
+
+    graph = helper.make_graph([seq_construct_node, seq_erase_node, seq_length_node],
+            name='seq_construct_erase_length_test',
+            inputs=[a_value_info, b_value_info, c_value_info, p_value_info],
+            outputs=[out_value_info])
+    model = helper.make_model(graph, producer_name='backend-test')
+    tf_rep = prepare(model)
+    output = tf_rep.run({'a':a, 'b':b, 'c':c, 'p':p})
+    np.testing.assert_almost_equal(output["Y"], 2)
+
+    # test SequenceConstruct and SequenceErase
+    seq_construct_node = helper.make_node('SequenceConstruct', ['a', 'b', 'c'], ['S'])
+    seq_erase_node = helper.make_node('SequenceErase', ['S','p'], ['S1'])
+    seq_at_node = helper.make_node('SequenceAt', ['S1', 'at'], ['Y'])
+
+    graph = helper.make_graph([seq_construct_node, seq_erase_node, seq_at_node],
+            name='seq_construct_erase_test',
+            inputs=[a_value_info, b_value_info, c_value_info, p_value_info, at_value_info],
+            outputs=[out_value_info])
+    model = helper.make_model(graph, producer_name='backend-test')
+    tf_rep = prepare(model)
+    output = tf_rep.run({'a':a, 'b':b, 'c':c, 'p':p, 'at':0})
+    np.testing.assert_almost_equal(output["Y"], b)
+    output = tf_rep.run({'a':a, 'b':b, 'c':c, 'p':p, 'at':1})
+    np.testing.assert_almost_equal(output["Y"], c)
 
   def test_relu_node_inplace(self):
     X = np.random.randn(3, 2).astype(np.float32)


### PR DESCRIPTION
Add sequence ops support for opset 11 to tf-1.x branch. The same
implementation can found in PR https://github.com/onnx/onnx-tensorflow/pull/560