### PR TITLE
Add opset 11 support for GatherElements

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,8 +1,8 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: dd94ceb36146f386ea17259c5f4fbd9724a8089b )|
-|ONNX Version|Master ( commit id: cc2230603422bae893d5bc900d2d773ab34400a4 )|
+|ONNX-Tensorflow Version|Master ( commit id: e81ab6c434b432559c646d91aa3239e241d8dd64 )|
+|ONNX Version|Master ( commit id: 14a7477618ec418d987fd5207178e91bb4c98dfc )|
 |Tensorflow Version|v2.2.0|
 
 Notes:
@@ -62,7 +62,7 @@ Notes:
 |Floor|**1**|1|1|1|1|**6**|6|6|6|6|6|6|**13**:small_red_triangle:|
 |GRU|**1**:small_orange_diamond:|1:small_orange_diamond:|**3**:small_orange_diamond:|3:small_orange_diamond:|3:small_orange_diamond:|3:small_orange_diamond:|**7**:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|
 |Gather|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|
-|GatherElements|-|-|-|-|-|-|-|-|-|-|**11**:small_red_triangle:|11:small_red_triangle:|**13**:small_red_triangle:|
+|GatherElements|-|-|-|-|-|-|-|-|-|-|**11**|11|**13**:small_red_triangle:|
 |GatherND|-|-|-|-|-|-|-|-|-|-|**11**|**12**:small_red_triangle:|**13**:small_red_triangle:|
 |Gemm|**1**|1|1|1|1|**6**|**7**|7|**9**|9|**11**|11|**13**:small_red_triangle:|
 |GlobalAveragePool|**1**|1|1|1|1|1|1|1|1|1|1|1|1|

--- a/onnx_tf/handlers/backend/gather_elements.py
+++ b/onnx_tf/handlers/backend/gather_elements.py
@@ -1,0 +1,58 @@
+import tensorflow as tf
+
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+from .gather_and_scatter_mixin import GatherAndScatterMixin
+
+
+@onnx_op("GatherElements")
+class GatherElements(GatherAndScatterMixin, BackendHandler):
+
+  @classmethod
+  def version_11(cls, node, **kwargs):
+    # GatherElements takes two inputs data and indices of the same rank r >= 1 and an optional attribute axis that identifies
+    # an axis of data (by default, the outer-most axis, that is axis 0). It is an indexing operation that produces its output by
+    # indexing into the input data tensor at index positions determined by elements of the indices tensor. Its output shape is the
+    # same as the shape of indices and consists of one value (gathered from the data) for each element in indices.
+
+    axis = node.attrs.get("axis", 0)
+    data = kwargs["tensor_dict"][node.inputs[0]]
+    indices = kwargs["tensor_dict"][node.inputs[1]]
+
+    # poocess negative axis
+    axis = axis if axis >= 0 else tf.add(tf.rank(data), axis)
+
+    # check are there any indices are out of bounds
+    result = cls.chk_idx_out_of_bounds_along_axis(data, axis, indices)
+    msg = 'GatherElements indices are out of bounds,'\
+      ' please double check the indices and retry.'
+    with tf.control_dependencies(
+        [tf.compat.v1.assert_equal(result, True, message=msg)]):
+      # process negative indices
+      indices = cls.process_neg_idx_along_axis(data, axis, indices)
+
+      # adapted from reference implementation in onnx/onnx/backend/test/case/node/gatherelements.py
+      if axis == 0:
+        axis_perm = tf.range(tf.rank(data))
+        data_swaped = data
+        index_swaped = indices
+      else:
+        axis_perm = tf.tensor_scatter_nd_update(tf.range(tf.rank(data)),
+                                                tf.constant([[0], [axis]]),
+                                                tf.constant([axis, 0]))
+        data_swaped = tf.transpose(data, perm=axis_perm)
+        index_swaped = tf.transpose(indices, perm=axis_perm)
+
+      idx_tensors_per_axis = tf.meshgrid(*list(
+          map(lambda x: tf.range(x, dtype=index_swaped.dtype),
+              index_swaped.shape.as_list())),
+                                        indexing='ij')
+      idx_tensors_per_axis[0] = index_swaped
+      dim_expanded_idx_tensors_per_axis = list(
+          map(lambda x: tf.expand_dims(x, axis=-1), idx_tensors_per_axis))
+      index_expanded = tf.concat(dim_expanded_idx_tensors_per_axis, axis=-1)
+
+      gathered = tf.gather_nd(data_swaped, index_expanded)
+      y = tf.transpose(gathered, perm=axis_perm)
+
+      return [y]

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -54,7 +54,7 @@ backend_opset_version = {
     'Floor': [1, 6],
     'GRU': [1, 3, 7],
     'Gather': [1, 11],
-    'GatherElements': [],
+    'GatherElements': [11],
     'GatherND': [11],
     'Gemm': [1, 6, 7, 9, 11],
     'GlobalAveragePool': [1],


### PR DESCRIPTION
Signed-off-by: Jason Plurad <pluradj@us.ibm.com>

---

* Tests added to `test_node.py`
* Verified `GatherElements` backend tests pass (3) with `test/backend/test_onnx_backend.py`
* Ran `yapf` against `onnx_tf/opset_version.py` so there is some additional reformatting in that file