### PR TITLE
Fix shape dtype in Slice when using default axes (tf-1.x)

### DIFF
--- a/onnx_tf/handlers/backend/slice.py
+++ b/onnx_tf/handlers/backend/slice.py
@@ -60,7 +60,7 @@ class Slice(BackendHandler):
     input_tensor_shape = tf.shape(input_tensor, out_type=ends.dtype)
 
     axes = tensor_dict[node.inputs[3]] if len(
-        node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends.dtype)
+        node.inputs) >= 4 else tf.range(tf.shape(starts, out_type=ends.dtype)[0])
 
     # process negative axes
     input_rank = tf.cast(tf.rank(input_tensor), axes.dtype)


### PR DESCRIPTION
Signed-off-by: Jason Plurad <pluradj@us.ibm.com>

----

When running the backend tests, I noticed `test_slice_default_axes_cpu` was failing with this error:

```
ValueError: Tensor conversion requested dtype int64 for Tensor with dtype int32: <tf.Tensor 'strided_slice:0' shape=() dtype=int32>
```

The call to `tf.shape(starts)` was returning `int32` which caused the surrounding call to `tf.range()` to fail. Using `tf.shape(starts, out_type=ends.dtype)` similar to line 60 puts the type casting into the correct location.
