### PR TITLE
Fix pooling string comparison and case for auto_pad (tf-1.x)

### DIFF
--- a/onnx_tf/common/pooling_helper.py
+++ b/onnx_tf/common/pooling_helper.py
@@ -173,6 +173,9 @@ def py_pool(input, kernel_shape, strides=None, dilations=None,
         padding = [0] * spatial_size * 2
 
     if type(padding) is not list and type(padding) is not np.ndarray:
+        if type(padding) is not str:
+            padding = padding.decode("UTF-8")
+
         if padding.lower().startswith("same"):
             padding = calc_pads_same(inp_sp_shape, kernel_shape, strides,
                                      dilations, padding)

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -1140,7 +1140,7 @@ class TestNode(unittest.TestCase):
     kernel_shape = [3, 3]
     strides = [2, 2]
     dilations = [3, 3]
-    auto_pad = "same_lower"
+    auto_pad = "SAME_LOWER"
 
     input_shape = [10, 3, 24, 24]
     self._test_pooling(input_shape=input_shape, kernel_shape=kernel_shape,


### PR DESCRIPTION
Signed-off-by: Jason Plurad <pluradj@us.ibm.com>

---

This fixes a test failure in the backend tests. Steps to recreate:

1. Regenerate the ONNX backend test data with `backend-test-tools generate-data`. Not clear on why the error does not occur before regenerating the test data.
2. Run the ONNX-TF backend tests with `pytest -v -s -k 'not _cuda' test/backend/test_onnx_backend.py`

Error reported:

```
test/backend/test_onnx_backend.py::OnnxBackendNodeModelTest::test_averagepool_2d_same_lower_cpu 2020-06-16 16:05:46.684938: W tensorflow/core/framework/op_kernel.cc:1639] Invalid argument: TypeError: startswith first arg must be bytes or a tuple of bytes, not str
Traceback (most recent call last):

  File "/Users/pluradj/anaconda3/envs/onnx-tf1-dev/lib/python3.7/site-packages/tensorflow_core/python/ops/script_ops.py", line 235, in __call__
    ret = func(*args)

  File "/Users/pluradj/src/github/pluradj/onnx-tensorflow/opset11-tf1x/onnx_tf/common/pooling_helper.py", line 176, in py_pool
    if padding.lower().startswith("same"):

TypeError: startswith first arg must be bytes or a tuple of bytes, not str

FAILED
```

The fix is to decode the `bytes` into a `string` before doing any string operations on it. This is similar to what is done on `pooling_type` earlier in the function.