### PR TITLE
Updated Dropout operator to support Opset 12 and 13.

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -49,7 +49,7 @@ Notes:
 |DequantizeLinear|-|-|-|-|-|-|-|-|-|**10**|10|10|**13**:small_red_triangle:|DequantizeLinear|
 |Det|-|-|-|-|-|-|-|-|-|-|**11**|11|11|Det|
 |Div|**1**|1|1|1|1|**6**|**7**|7|7|7|7|7|**13**:small_red_triangle:|Div|
-|Dropout|**1**|1|1|1|1|**6**|**7**|7|7|**10**|10|**12**:small_red_triangle:|**13**:small_red_triangle:|Dropout|
+|Dropout|**1**|1|1|1|1|**6**|**7**|7|7|**10**|10|**12**|**13**|Dropout|
 |DynamicQuantizeLinear|-|-|-|-|-|-|-|-|-|-|**11**|11|11|DynamicQuantizeLinear|
 |Einsum|-|-|-|-|-|-|-|-|-|-|-|**12**:small_red_triangle:|12:small_red_triangle:|Einsum|
 |Elu|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|Elu|

--- a/onnx_tf/handlers/backend/dropout.py
+++ b/onnx_tf/handlers/backend/dropout.py
@@ -13,12 +13,41 @@ class Dropout(BackendHandler):
 
   @classmethod
   def _common(cls, node, **kwargs):
-    x = kwargs["tensor_dict"][node.inputs[0]]
+    tensor_dict = kwargs["tensor_dict"]
+    x = tensor_dict[node.inputs[0]]
     attrs = copy.deepcopy(node.attrs)
-    if cls.SINCE_VERSION >= 7 or attrs.pop("is_test", 0) == 1:
+
+    if cls.SINCE_VERSION < 7:
+      attrs["keep_prob"] = 1 - attrs.pop("ratio", 0.5)
+      return [cls.make_tensor_from_onnx_node(node, attrs=attrs, **kwargs)]
+    elif cls.SINCE_VERSION < 12 or attrs.pop("is_test", 0) == 1: # for Opset 7, 10
       return [x]
-    attrs["keep_prob"] = 1 - attrs.pop("ratio", 0.5)
-    return [cls.make_tensor_from_onnx_node(node, attrs=attrs, **kwargs)]
+    else: # for Opset 12, 13
+      # ratio and training_mode are optional and passed as inputs
+      ratio = 0.5 # default ratio
+      if len(node.inputs) > 1:
+        ratio = tensor_dict[node.inputs[1]]
+      training_mode = False # default is false
+      if len(node.inputs) == 3:
+        training_mode = tensor_dict[node.inputs[2]]
+      
+      return_mask = len(node.outputs) == 2 # if there are 2 outputs, mask is requested
+      if ratio == 0 or training_mode is False: # Inferencing
+        if return_mask is True:
+          return x, tf.ones(x.shape, dtype=tf.bool)
+        else:
+          return [x]
+      else: # Training
+        # seed is passed in as an attribute
+        seed = attrs.pop("seed", None)
+        noise_shape = None # noise_shape is not passed in so default to None
+        dropout_result = cls.make_tensor_from_onnx_node(node, inputs=[x, ratio, noise_shape, seed], attrs=attrs, **kwargs)
+        if return_mask is True:
+          # Create the mask based on the result of the Dropout
+          mask = tf.dtypes.cast(dropout_result, tf.bool)
+          return dropout_result, mask
+        else:
+          return [dropout_result]
 
   @classmethod
   def version_1(cls, node, **kwargs):
@@ -34,4 +63,12 @@ class Dropout(BackendHandler):
 
   @classmethod
   def version_10(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_12(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
     return cls._common(node, **kwargs)

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -40,7 +40,7 @@ backend_opset_version = {
     'Det': [11],
     'DictVectorizer': [],
     'Div': [1, 6, 7],
-    'Dropout': [1, 6, 7, 10],
+    'Dropout': [1, 6, 7, 10, 12, 13],
     'DynamicQuantizeLinear': [11],
     'Einsum': [],
     'Elu': [1, 6],

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -626,15 +626,81 @@ class TestNode(unittest.TestCase):
     # Since current ONNX only support inference and
     # dropout at inference mode is a no-op,
     # therefore dropout is always a no-op operator
-    # in ONNX.
-    node_def = helper.make_node("Dropout", ["X"], ["Y"])
-    if legacy_opset_pre_ver(7):
-      # at inference mode, is_test is always set to 1
-      node_def = helper.make_node("Dropout", ["X"], ["Y"], is_test=1)
+    # in ONNX. This has changed in Opset 12. In Opset
+    # 12 ONNX has added support for training.
+    
     x = self._get_rnd_float32(shape=[3, 4, 5])
-    y = x
-    output = run_node(node_def, [x])
-    np.testing.assert_equal(output["Y"], y)
+    if legacy_opset_pre_ver(7):
+      # at inference mode, is_test attribute is always set to 1
+      node_def = helper.make_node("Dropout", ["X"], ["Y"], is_test=1)
+      y = x # output is same is input i.e. nothing is dropped
+      output = run_node(node_def, [x])
+      np.testing.assert_equal(output["Y"], y)
+    elif legacy_opset_pre_ver(12): # for Opset 7, 10
+      # no is_test attribute anymore
+      node_def = helper.make_node("Dropout", ["X"], ["Y"])
+      y = x # output is same is input i.e. nothing is dropped
+      output = run_node(node_def, [x])
+      np.testing.assert_equal(output["Y"], y)
+    else: # for Opset 12, 13
+      # Inference mode tests
+      #   training_mode is false by default
+      #   ratio is ignored
+      #   nothing will be dropped from the input data 
+      #   if mask is requested as output it will contain all ones
+
+      # Inference, mask not requested
+      node_def = helper.make_node("Dropout", ["X"], ["Y"])
+      y = x # output is same is input i.e. nothing is dropped
+      output = run_node(node_def, [x])
+      np.testing.assert_equal(output["Y"], y)
+
+      # Inference, mask requested
+      node_def = helper.make_node("Dropout", inputs=["X"], outputs=["Y", "Z"])
+      y = x # output is same is input i.e. nothing is dropped
+      z = np.ones(x.shape, dtype=bool) # mask returned is all ones
+      output = run_node(node_def, [x])
+      np.testing.assert_equal(output["Y"], y)
+      np.testing.assert_equal(output["Z"], z)
+
+      # Training mode tests
+      #   training_mode is true
+      #   output is  a random dropout that scales masked
+      #     input using the following equation
+      #     output = scale * data * mask
+      #     scale = 1. / (1. - ratio)
+
+      ratio = np.float32(0.5)
+      training_mode = np.bool_(True)
+      no_of_runs = 20 # run 20 times and make sure that on average we have the desired dropout
+
+      # Training, mask not requested
+      node_def = helper.make_node("Dropout", inputs=["X", "X1", "X2"], outputs=["Y"])
+      sum_ratio_in_output = 0
+      for _ in range(no_of_runs):
+        output = run_node(node_def, [x, ratio, training_mode])
+        output_nonzero_count = np.count_nonzero(output["Y"])
+        output_size = output["Y"].size
+        ratio_in_output = (output_size - output_nonzero_count) / output_size
+        sum_ratio_in_output += ratio_in_output
+      ratio_in_output = sum_ratio_in_output / no_of_runs
+      # test by confirming that the dropout is close to the ratio passed in
+      np.testing.assert_almost_equal(ratio_in_output, ratio, decimal=1)
+
+      # Training, mask requested
+      node_def = helper.make_node("Dropout", inputs=["X", "X1", "X2"], outputs=["Y", "Z"])
+      sum_ratio_in_output = 0
+      for _ in range(no_of_runs):
+        output = run_node(node_def, [x, ratio, training_mode])
+        output_nonzero_count = np.count_nonzero(output["Y"])
+        output_size = output["Y"].size
+        ratio_in_output = (output_size - output_nonzero_count) / output_size
+        sum_ratio_in_output += ratio_in_output
+      ratio_in_output = sum_ratio_in_output / no_of_runs
+      # test by confirming that the dropout is close to the ratio passed in
+      np.testing.assert_almost_equal(ratio_in_output, ratio, decimal=1)
+      # test mask
+      np.testing.assert_equal(output["Z"], output["Y"].astype(bool))
 
   def test_dot(self):
     # this op is removed

--- a/test/backend/test_onnx_backend.py
+++ b/test/backend/test_onnx_backend.py
@@ -115,6 +115,13 @@ backend_test.exclude(r'test_pow_types_float[0-9]+_uint64+_[a-z,_]*')
 # TF session run does not support sequence/RaggedTensor as model inputs
 backend_test.exclude(r'test_sequence_insert+_[a-z,_]*')
 
+# Exclude tests for Dropout training that have randomness dependent on
+# the different implementations
+backend_test.exclude('test_training_dropout_default_cpu')
+backend_test.exclude('test_training_dropout_cpu')
+backend_test.exclude('test_training_dropout_default_mask_cpu')
+backend_test.exclude('test_training_dropout_mask_cpu')
+
 # import all test cases at global scope to make them visible to python.unittest
 globals().update(backend_test.enable_report().test_cases)
 


### PR DESCRIPTION
As of Opset 12, the Dropout operator now supports training mode. I have created tests for this. The test is an average of 20 runs of the operator. It checks that the ratio of dropouts in the output is almost equal to the  ratio requested.
Opset 13 supports a bfloat16 input tensor. I have verified that tf.nn.dropout works fine with bfloat16 tensors. I have not created a test case for this.
This will close issue #552 