### PR TITLE
Fix dtype issues in sequence operators

### DIFF
--- a/onnx_tf/handlers/backend/sequence_at.py
+++ b/onnx_tf/handlers/backend/sequence_at.py
@@ -23,8 +23,8 @@ class SequenceAt(BackendHandler):
 
     if seq_length is None: return True
 
-    seq_length = tf.cast(seq_length, tf.int32)
-    pos = tf.cast(pos, tf.int32)
+    seq_length = tf.cast(seq_length, pos.dtype)
+
     cond1 = tf.greater_equal(pos, tf.negative(seq_length))
     cond2 = tf.less_equal(pos, seq_length - 1)
 

--- a/onnx_tf/handlers/backend/sequence_erase.py
+++ b/onnx_tf/handlers/backend/sequence_erase.py
@@ -19,8 +19,8 @@ class SequenceErase(BackendHandler):
 
     :return: True if position is in-bounds 
     """
-    seq_length = tf.shape(input_seq.to_sparse())[0]
-    pos = tf.cast(pos, tf.int32)
+    seq_length = tf.shape(input_seq.to_sparse(), out_type=pos.dtype)[0]
+
     cond1 = tf.greater_equal(pos, tf.negative(seq_length))
     cond2 = tf.less_equal(pos, seq_length - 1)
 

--- a/onnx_tf/handlers/backend/sequence_insert.py
+++ b/onnx_tf/handlers/backend/sequence_insert.py
@@ -18,8 +18,7 @@ class SequenceInsert(BackendHandler):
 
     :return: True if position is in-bounds.
     """
-    seq_length = tf.shape(input_seq.to_sparse())[0]
-    pos = tf.cast(pos, tf.int32)
+    seq_length = tf.shape(input_seq.to_sparse(), out_type=pos.dtype)[0]
 
     cond1 = tf.greater_equal(pos, tf.negative(seq_length))
     cond2 = tf.less_equal(pos, seq_length)

--- a/onnx_tf/handlers/backend/sequence_length.py
+++ b/onnx_tf/handlers/backend/sequence_length.py
@@ -12,4 +12,4 @@ class SequenceLength(BackendHandler):
     tensor_dict = kwargs["tensor_dict"]
     input_sequence = tensor_dict[node.inputs[0]]
 
-    return [tf.shape(input_sequence.to_sparse())[0]]
+    return [tf.shape(input_sequence.to_sparse(), out_type=tf.int64)[0]]


### PR DESCRIPTION
This PR fixes a couple of dtype issues in the sequence ops:
1. The output dtype should be int64 for SequenceLength
2. The position check casts to int32 when postion could be either
int32 or int64