### PR TITLE
LpPool operator implementation

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,8 +1,8 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: 355ee1c69f60fe350761fe57a0b7ba8319496af6 )|
-|ONNX Version|Master ( commit id: 925b3657924c0c16cd20b54595f41e76159b03ab )|
+|ONNX-Tensorflow Version|Master ( commit id: 5e17be08813b637c1a426c6ece4d3918af99a852 )|
+|ONNX Version|Master ( commit id: 14a7477618ec418d987fd5207178e91bb4c98dfc )|
 |Tensorflow Version|v2.2.0|
 
 Notes:
@@ -46,7 +46,7 @@ Notes:
 |Cosh|-|-|-|-|-|-|-|-|**9**|9|9|9|9|
 |CumSum|-|-|-|-|-|-|-|-|-|-|**11**:small_orange_diamond:|11:small_orange_diamond:|11:small_orange_diamond:|
 |DepthToSpace|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|
-|DequantizeLinear|-|-|-|-|-|-|-|-|-|**10**|10|10|10|
+|DequantizeLinear|-|-|-|-|-|-|-|-|-|**10**|10|10|**13**:small_red_triangle:|
 |Det|-|-|-|-|-|-|-|-|-|-|**11**|11|11|
 |Div|**1**|1|1|1|1|**6**|**7**|7|7|7|7|7|**13**:small_red_triangle:|
 |Dropout|**1**|1|1|1|1|**6**|**7**|7|7|**10**|10|**12**:small_red_triangle:|**13**:small_red_triangle:|
@@ -86,7 +86,7 @@ Notes:
 |LogSoftmax|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|
 |Loop|**1**|1|1|1|1|1|1|1|1|1|**11**|11|11|
 |LpNormalization|**1**|1|1|1|1|1|1|1|1|1|1|1|1|
-|LpPool|**1**:small_red_triangle:|**2**:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|2:small_red_triangle:|**11**:small_red_triangle:|11:small_red_triangle:|11:small_red_triangle:|
+|LpPool|**1**|**2**|2|2|2|2|2|2|2|2|**11**|11|11|
 |MatMul|**1**|1|1|1|1|1|1|1|**9**|9|9|9|**13**:small_red_triangle:|
 |MatMulInteger|-|-|-|-|-|-|-|-|-|**10**|10|10|10|
 |Max|**1**|1|1|1|1|**6**|6|**8**|8|8|8|**12**|**13**|
@@ -111,7 +111,7 @@ Notes:
 |Pow|**1**|1|1|1|1|1|**7**|7|7|7|7|**12**:small_red_triangle:|**13**:small_red_triangle:|
 |QLinearConv|-|-|-|-|-|-|-|-|-|**10**|10|10|10|
 |QLinearMatMul|-|-|-|-|-|-|-|-|-|**10**|10|10|10|
-|QuantizeLinear|-|-|-|-|-|-|-|-|-|**10**|10|10|10|
+|QuantizeLinear|-|-|-|-|-|-|-|-|-|**10**|10|10|**13**:small_red_triangle:|
 |RNN|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**7**:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|
 |RandomNormal|**1**|1|1|1|1|1|1|1|1|1|1|1|1|
 |RandomNormalLike|**1**|1|1|1|1|1|1|1|1|1|1|1|1|
@@ -179,7 +179,7 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|9|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|
 
-ONNX-TF Supported Operators / ONNX Operators: 78 / 162
+ONNX-TF Supported Operators / ONNX Operators: 77 / 162
 
 Notes:
 1. Cast: Cast string to float32/float64/int32/int64 are not supported in Tensorflow.

--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,7 +1,7 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: e3f8919ae1becfc16b3f522e89c52c47d9f6a6d8 )|
+|ONNX-Tensorflow Version|Master ( commit id: 355ee1c69f60fe350761fe57a0b7ba8319496af6 )|
 |ONNX Version|Master ( commit id: 925b3657924c0c16cd20b54595f41e76159b03ab )|
 |Tensorflow Version|v2.2.0|
 
@@ -33,7 +33,7 @@ Notes:
 |Cast|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**9**:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|**13**:small_red_triangle:|
 |Ceil|**1**|1|1|1|1|**6**|6|6|6|6|6|6|**13**:small_red_triangle:|
 |Celu|-|-|-|-|-|-|-|-|-|-|-|**12**:small_red_triangle:|12:small_red_triangle:|
-|Clip|**1**|1|1|1|1|**6**|6|6|6|6|**11**|**12**:small_red_triangle:|**13**:small_red_triangle:|
+|Clip|**1**|1|1|1|1|**6**|6|6|6|6|**11**|**12**|**13**|
 |Compress|-|-|-|-|-|-|-|-|**9**|9|**11**|11|11|
 |Concat|**1**|1|1|**4**|4|4|4|4|4|4|**11**|11|**13**:small_red_triangle:|
 |ConcatFromSequence|-|-|-|-|-|-|-|-|-|-|**11**:small_red_triangle:|11:small_red_triangle:|11:small_red_triangle:|
@@ -179,7 +179,7 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|9|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|
 
-ONNX-TF Supported Operators / ONNX Operators: 77 / 162
+ONNX-TF Supported Operators / ONNX Operators: 78 / 162
 
 Notes:
 1. Cast: Cast string to float32/float64/int32/int64 are not supported in Tensorflow.

--- a/onnx_tf/common/pooling_helper.py
+++ b/onnx_tf/common/pooling_helper.py
@@ -153,6 +153,9 @@ def py_pool(input, kernel_shape, strides=None, dilations=None,
     else:
         input_dtype_min = np.finfo(input_dtype).min
 
+    if pooling_type == "LP":
+      rootN = (1.0 / p)
+
     def _loop_over_output(batch, channel):
         dims = [range(output_sp_shape[d]) for d in range(spatial_size)]
         for counters in itertools.product(*dims):
@@ -182,8 +185,7 @@ def py_pool(input, kernel_shape, strides=None, dilations=None,
                     val_sum += val
                     val_count += 1
                 elif pooling_type == "LP":
-                    val_sum += (val ** p)
-                    val_count += 1
+                    val_sum += abs(val ** p)
                 else:
                     if val > maxval:
                         maxval = val
@@ -198,7 +200,7 @@ def py_pool(input, kernel_shape, strides=None, dilations=None,
             if pooling_type == "AVG":
                 out_pool[ind] = val_sum / val_count
             elif pooling_type == "LP":
-                out_pool[ind] = val_sum ** (1.0 / p)
+                out_pool[ind] = val_sum ** rootN
             else:
                 out_pool[ind] = maxval
                 out_ind[ind] = maxind

--- a/onnx_tf/common/pooling_helper.py
+++ b/onnx_tf/common/pooling_helper.py
@@ -120,7 +120,7 @@ def _pooling_output_shape(input_size, ksize, stride, dilation, pad, ceil_mode):
 
 def py_pool(input, kernel_shape, strides=None, dilations=None,
             padding=None, ceil_mode=False, pooling_type="MAX",
-            include_indices=True):
+            include_indices=True, p=2):
     """
         Implementation of Max and Average pool operations in Python
         Args:
@@ -133,8 +133,10 @@ def py_pool(input, kernel_shape, strides=None, dilations=None,
                           [x1_begin, x2_begin...x1_end, x2_end,...]
             ceil_mode:    whether to use ceil or floor (default) to compute
                           the output shape.
-            pooling_type: specify pooling type. Values can be "MAX" or "AVG".
+            pooling_type: specifies pooling type. Values can be "MAX", "AVG" or
+                          "LP"
             include_indices: should indices be included in the output
+            p:            specifies the p parameter for LpPooling
       Return:
             pooled:       output data from max pooling across the input
             ind:          indices of the selected max values from the input
@@ -167,7 +169,7 @@ def py_pool(input, kernel_shape, strides=None, dilations=None,
                 cur_range = [i for i in range(dim_start,
                                               dim_end, dilations[dim])]
                 input_ranges.append(cur_range)
-            if pooling_type == "AVG":
+            if pooling_type in ["AVG", "LP"]:
                 val_sum = 0
                 val_count = 0
             else:
@@ -178,6 +180,9 @@ def py_pool(input, kernel_shape, strides=None, dilations=None,
                 val = input[ind]
                 if pooling_type == "AVG":
                     val_sum += val
+                    val_count += 1
+                elif pooling_type == "LP":
+                    val_sum += (val ** p)
                     val_count += 1
                 else:
                     if val > maxval:
@@ -192,6 +197,8 @@ def py_pool(input, kernel_shape, strides=None, dilations=None,
             ind = (batch, channel) + counters
             if pooling_type == "AVG":
                 out_pool[ind] = val_sum / val_count
+            elif pooling_type == "LP":
+                out_pool[ind] = val_sum ** (1.0 / p)
             else:
                 out_pool[ind] = maxval
                 out_ind[ind] = maxind

--- a/onnx_tf/handlers/backend/clip.py
+++ b/onnx_tf/handlers/backend/clip.py
@@ -2,17 +2,26 @@ import tensorflow as tf
 
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
-from onnx_tf.handlers.handler import tf_func
 
 
 @onnx_op("Clip")
-@tf_func(tf.clip_by_value)
 class Clip(BackendHandler):
+
+  @classmethod
+  def args_check(cls, node, **kwargs):
+    x = kwargs["tensor_dict"][node.inputs[0]]
+    # uint64 cannot upcast to any tensorflow supported datatype
+    # for tf.clip_by_value that didn't lose precision
+    if x.dtype == tf.uint64:
+      exception.OP_UNSUPPORTED_EXCEPT(
+          "Clip input, min and max in " + str(x.dtype) + " datatype",
+          "Tensorflow")
 
   @classmethod
   def _common(cls, node, **kwargs):
     tensor_dict = kwargs["tensor_dict"]
     x = tensor_dict[node.inputs[0]]
+    x_dtype = x.dtype
 
     if cls.SINCE_VERSION < 11:
       # min/max were required and passed as attributes
@@ -20,15 +29,24 @@ class Clip(BackendHandler):
       clip_value_max = node.attrs.get("max", tf.reduce_max(x))
     else:
       # min/max are optional and passed as inputs
-      clip_value_min = tensor_dict[
-          "min"] if "min" in tensor_dict else x.dtype.min
-      clip_value_max = tensor_dict[
-          "max"] if "max" in tensor_dict else x.dtype.max
+      clip_value_min = tensor_dict[node.inputs[1]] if len(
+          node.inputs) > 1 else x_dtype.min
+      clip_value_max = tensor_dict[node.inputs[2]] if len(
+          node.inputs) > 2 else x_dtype.max
 
-    return [
-        cls.make_tensor_from_onnx_node(
-            node, inputs=[x, clip_value_min, clip_value_max])
-    ]
+    # tf.clip_by_value doesn't support uint8, uint16, uint32, int8 and int16
+    # dtype for x, therefore need to upcast it to tf.int32 or tf.int64
+    if x_dtype in [tf.uint8, tf.uint16, tf.uint32, tf.int8, tf.int16]:
+      cast_to = tf.int64 if x_dtype == tf.uint32 else tf.int32
+      x = tf.cast(x, cast_to)
+      clip_value_min = tf.cast(clip_value_min, cast_to)
+      clip_value_max = tf.cast(clip_value_max, cast_to)
+      y = tf.clip_by_value(x, clip_value_min, clip_value_max)
+      y = tf.cast(y, x_dtype)
+    else:
+      y = tf.clip_by_value(x, clip_value_min, clip_value_max)
+
+    return [y]
 
   @classmethod
   def version_1(cls, node, **kwargs):
@@ -40,4 +58,12 @@ class Clip(BackendHandler):
 
   @classmethod
   def version_11(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_12(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
     return cls._common(node, **kwargs)

--- a/onnx_tf/handlers/backend/dilated_pooling.py
+++ b/onnx_tf/handlers/backend/dilated_pooling.py
@@ -577,7 +577,7 @@ class DilatedPooling(object):
   def _lp_pool(self, input, ksize, strides, padding):
     window_size = np.prod(ksize)
 
-    input = tf.math.pow(input, self.p) * window_size
+    input = tf.math.pow(tf.math.abs(input), self.p) * window_size
     pooled = tf.nn.avg_pool(input, ksize=ksize, strides=strides, padding=padding)
     pooled = tf.math.pow(pooled, 1.0 / self.p)
 
@@ -593,7 +593,7 @@ class DilatedPooling(object):
 
     if self.is_explicit_padding or self.padding.lower() == "same_lower" \
             or (self.padding.lower() == "same_upper" and
-                self.count_include_pad):
+                self.count_include_pad) or self.pooling_type.upper() == "LP":
       # pad the input
       self._pad_input()
 

--- a/onnx_tf/handlers/backend/dilated_pooling.py
+++ b/onnx_tf/handlers/backend/dilated_pooling.py
@@ -151,7 +151,8 @@ class DilatedPooling(object):
                padding="VALID",
                ceil_mode=False,
                count_include_pad=False,
-               pooling_type="MAX"):
+               pooling_type="MAX",
+               p=2):
     self.input = tf.convert_to_tensor(input)
 
     self.kernel_shape = kernel_shape
@@ -162,6 +163,7 @@ class DilatedPooling(object):
     self.ceil_mode = ceil_mode
     self.count_include_pad = count_include_pad
     self.pooling_type = pooling_type.upper()
+    self.p = p
 
     self.is_known_shape = self.input.shape.is_fully_defined()
     self.spatial_size = len(kernel_shape)
@@ -572,6 +574,15 @@ class DilatedPooling(object):
 
     return (pooled, new_ind)
 
+  def _lp_pool(self, input, ksize, strides, padding):
+    window_size = np.prod(ksize)
+
+    input = tf.math.pow(input, self.p) * window_size
+    pooled = tf.nn.avg_pool(input, ksize=ksize, strides=strides, padding=padding)
+    pooled = tf.math.pow(pooled, 1.0 / self.p)
+
+    return pooled
+
   def dilated_pool(self, force_custom_impl=False):
     """
             Does N-D dilated max/avg pooling. Pads the input if explicit or
@@ -614,8 +625,8 @@ class DilatedPooling(object):
     elif self.spatial_size < 4 and (self.strides == [1] * self.spatial_size or
             self.dilations == [1] * self.spatial_size) and \
             not force_custom_impl:
-      # if strides == 1 use tf.nn.pool directly
-      if self.strides == [1] * self.spatial_size:
+      # if strides == 1 and not LpPool use tf.nn.pool directly
+      if self.strides == [1] * self.spatial_size and self.pooling_type != "LP":
         pooled = tf.nn.pool(
             self.input,
             window_shape=self.kernel_shape,
@@ -629,6 +640,8 @@ class DilatedPooling(object):
           op = tf.nn.max_pool
         elif self.pooling_type == "AVG":
           op = tf.nn.avg_pool
+        elif self.pooling_type == "LP":
+          op = self._lp_pool
         else:
           raise ValueError("%d-D %s pooling is not supported." %
                            (self.spatial_size, self.pooling_type))
@@ -644,12 +657,20 @@ class DilatedPooling(object):
         # pad the input
         self._pad_input()
       input_ = self._remove_dilations()
-      pooled = tf.nn.pool(
-          input_,
-          window_shape=self.kernel_shape,
-          strides=self.kernel_shape,
-          padding="VALID",
-          pooling_type=self.pooling_type)
+      if self.pooling_type=="LP":
+        pooled = self._lp_pool(
+            input_,
+            ksize=self.kernel_shape,
+            strides=self.kernel_shape,
+            padding="VALID")
+
+      else:
+        pooled = tf.nn.pool(
+            input_,
+            window_shape=self.kernel_shape,
+            strides=self.kernel_shape,
+            padding="VALID",
+            pooling_type=self.pooling_type)
     return pooled
 
   def is_supported(self):
@@ -658,7 +679,8 @@ class DilatedPooling(object):
             supported for average pool
         """
     # check for maxpool
-    if self.pooling_type.startswith("MAX"):
+    if self.pooling_type.startswith("MAX") or \
+       self.pooling_type=="LP":
       return True
     else:
       # if count_include_pad is true it is fully supported

--- a/onnx_tf/handlers/backend/lp_pool.py
+++ b/onnx_tf/handlers/backend/lp_pool.py
@@ -1,0 +1,24 @@
+from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import onnx_op
+from .pool_mixin import PoolMixin
+
+
+@onnx_op("LpPool")
+class LpPool(PoolMixin, BackendHandler):
+
+  @classmethod
+  def _common(cls, node, **kwargs):
+    return cls.pool(node, kwargs["tensor_dict"], "LP",
+                    kwargs.get("strict", True))
+
+  @classmethod
+  def version_1(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_2(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_11(cls, node, **kwargs):
+    return cls._common(node, **kwargs)

--- a/onnx_tf/handlers/backend/pool_mixin.py
+++ b/onnx_tf/handlers/backend/pool_mixin.py
@@ -26,6 +26,8 @@ class PoolMixin(object):
     dilations = node.attrs.get("dilations", [1] * spatial_size)
     ceil_mode = bool(node.attrs.get("ceil_mode", 0))
     pads = node.attrs.get("auto_pad", "NOTSET")
+    p = node.attrs.get("p", 2)
+
     if pads == "NOTSET":
       pads = node.attrs.get("pads", [0] * spatial_size * 2)
       # In case shape is fully defined, check if pads match
@@ -44,6 +46,8 @@ class PoolMixin(object):
       pooling_name = "MaxPool"
     elif pooling_type == "MAX_WITH_ARGMAX":
       pooling_name = "MaxPoolWithArgmax"
+    elif pooling_type == "LP":
+      pooling_name = "LpPool"
 
     if spatial_size > 3:
       exception.OP_UNSUPPORTED_EXCEPT(
@@ -71,16 +75,16 @@ class PoolMixin(object):
         padding=pads,
         ceil_mode=ceil_mode,
         pooling_type=pooling_type,
-        count_include_pad=count_include_pad)
+        count_include_pad=count_include_pad,
+        p=p)
     if not dp.is_supported():
       if strict:
         logger.warning("Using the pooling op in compatibility mode. "
-                      "This means your graph cannot be serialized.",
-                      UserWarning)
+                      "This means your graph cannot be serialized.")
 
         result = tf.numpy_function(py_pool, [
                 orig_x, kernel_shape, strides, dilations, pads, ceil_mode,
-                "AVG", False
+                pooling_type, False
             ], orig_x.dtype)
 
         if orig_x.shape.is_fully_defined():
@@ -92,7 +96,7 @@ class PoolMixin(object):
         result.set_shape(output_shape)
         return [result]
       else:
-        exception.OP_UNSUPPORTED_EXCEPT("strict == 0 and average pool"
+        exception.OP_UNSUPPORTED_EXCEPT("strict == 0 and " + pooling_name +
                                         " arguments not compatible",
                                         "Tensorflow")
 
@@ -100,7 +104,7 @@ class PoolMixin(object):
       return (dp.dilated_pool(), None)
 
     # select correct op depending on the pooling type
-    pooling_op = dilated_pool if pooling_type in ["MAX", "AVG"] else \
+    pooling_op = dilated_pool if pooling_type in ["MAX", "AVG", "LP"] else \
         dp.dilated_maxpool_with_argmax
 
     # select the correct transpose ops depending on the input storage format

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -85,7 +85,7 @@ backend_opset_version = {
     'LogSoftmax': [1, 11],
     'Loop': [1, 11],
     'LpNormalization': [1],
-    'LpPool': [],
+    'LpPool': [1, 2, 11],
     'MatMul': [1, 9],
     'MatMulInteger': [10],
     'Max': [1, 6, 8, 12, 13],

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -22,7 +22,7 @@ backend_opset_version = {
     'CategoryMapper': [],
     'Ceil': [1, 6],
     'Celu': [],
-    'Clip': [1, 6, 11],
+    'Clip': [1, 6, 11, 12, 13],
     'Compress': [9, 11],
     'Concat': [1, 4, 11],
     'ConcatFromSequence': [],

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -1411,10 +1411,10 @@ class TestNode(unittest.TestCase):
                     count_include_pad=None,
                     pooling_type="MAX",
                     input_dtype=np.float32,
-                    p=2):
+                    p=None):
 
     op = "MaxPool" if pooling_type.upper().startswith("MAX") else \
-         "AveragePool" if pooling_type.upper()=="AVG" else "LpPool"
+         "AveragePool" if pooling_type.upper() == "AVG" else "LpPool"
     node_def_kwargs = {
         "op_type": op,
         "inputs": ["X"],
@@ -1437,6 +1437,8 @@ class TestNode(unittest.TestCase):
       ceil_mode = 0
     if count_include_pad is not None:
       node_def_kwargs["count_include_pad"] = count_include_pad
+    if p is not None:
+      node_def_kwargs["p"] = p
 
     node_def = helper.make_node(**node_def_kwargs)
 
@@ -1460,7 +1462,8 @@ class TestNode(unittest.TestCase):
                           include_indices=False,
                           p=p)
 
-    np.testing.assert_almost_equal(output["Y"], test_output)
+    np.testing.assert_almost_equal(output["Y"], test_output,
+                                   decimal=5 if pooling_type=="LP" else 7)
 
   def test_max_pool_2d(self):
     kernel_shape = [1, 2]
@@ -1875,6 +1878,7 @@ class TestNode(unittest.TestCase):
     self._test_pooling(input_shape=input_shape,
                        kernel_shape=kernel_shape,
                        strides=strides,
+                       pooling_type="LP",
                        p=p)
 
   def test_lp2_pool_2d_same_lower(self):
@@ -1888,6 +1892,7 @@ class TestNode(unittest.TestCase):
                        kernel_shape=kernel_shape,
                        strides=strides,
                        auto_pad=auto_pad,
+                       pooling_type="LP",
                        p=p)
 
   def test_lp2_pool_2d_same_upper(self):
@@ -1901,17 +1906,7 @@ class TestNode(unittest.TestCase):
                        kernel_shape=kernel_shape,
                        strides=strides,
                        auto_pad=auto_pad,
-                       p=p)
-
-  def test_lp2_pool_3d(self):
-    kernel_shape = [3, 3, 3]
-    strides = [2, 2, 2]
-    p = 2
-
-    input_shape = [10, 3, 23, 23, 23]
-    self._test_pooling(input_shape=input_shape,
-                       kernel_shape=kernel_shape,
-                       strides=strides,
+                       pooling_type="LP",
                        p=p)
 
   def test_lp2_pool_2d_pads(self):
@@ -1925,6 +1920,19 @@ class TestNode(unittest.TestCase):
                        kernel_shape=kernel_shape,
                        strides=strides,
                        pads=pads,
+                       pooling_type="LP",
+                       p=p)
+
+  def test_lp2_pool_3d(self):
+    kernel_shape = [3, 3, 3]
+    strides = [2, 2, 2]
+    p = 2
+
+    input_shape = [10, 3, 23, 23, 23]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       pooling_type="LP",
                        p=p)
 
   def test_lp2_pool_1d(self):
@@ -1936,6 +1944,7 @@ class TestNode(unittest.TestCase):
     self._test_pooling(input_shape=input_shape,
                        kernel_shape=kernel_shape,
                        strides=strides,
+                       pooling_type="LP",
                        p=p)
 
   def test_lp3_pool_2d_pads(self):
@@ -1949,6 +1958,7 @@ class TestNode(unittest.TestCase):
                        kernel_shape=kernel_shape,
                        strides=strides,
                        pads=pads,
+                       pooling_type="LP",
                        p=p)
 
   def test_lp3_pool_3d(self):
@@ -1960,6 +1970,7 @@ class TestNode(unittest.TestCase):
     self._test_pooling(input_shape=input_shape,
                        kernel_shape=kernel_shape,
                        strides=strides,
+                       pooling_type="LP",
                        p=p)
 
   def test_mean_variance_normalization(self):

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -1410,9 +1410,11 @@ class TestNode(unittest.TestCase):
                     ceil_mode=None,
                     count_include_pad=None,
                     pooling_type="MAX",
-                    input_dtype=np.float32):
+                    input_dtype=np.float32,
+                    p=2):
 
-    op = "MaxPool" if pooling_type.upper().startswith("MAX") else "AveragePool"
+    op = "MaxPool" if pooling_type.upper().startswith("MAX") else \
+         "AveragePool" if pooling_type.upper()=="AVG" else "LpPool"
     node_def_kwargs = {
         "op_type": op,
         "inputs": ["X"],
@@ -1455,7 +1457,8 @@ class TestNode(unittest.TestCase):
                           padding=pads,
                           ceil_mode=ceil_mode,
                           pooling_type=pooling_type,
-                          include_indices=False)
+                          include_indices=False,
+                          p=p)
 
     np.testing.assert_almost_equal(output["Y"], test_output)
 
@@ -1862,6 +1865,102 @@ class TestNode(unittest.TestCase):
                        kernel_shape=kernel_shape,
                        strides=strides,
                        pooling_type="AVG")
+
+  def test_lp2_pool_2d(self):
+    kernel_shape = [1, 2]
+    strides = [1, 2]
+    p = 2
+
+    input_shape = [10, 10, 4, 4]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       p=p)
+
+  def test_lp2_pool_2d_same_lower(self):
+    kernel_shape = [1, 2]
+    strides = [1, 2]
+    p = 2
+    auto_pad = "SAME_LOWER"
+
+    input_shape = [10, 10, 7, 7]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       auto_pad=auto_pad,
+                       p=p)
+
+  def test_lp2_pool_2d_same_upper(self):
+    kernel_shape = [1, 2]
+    strides = [1, 2]
+    p = 2
+    auto_pad = "SAME_UPPER"
+
+    input_shape = [10, 10, 7, 7]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       auto_pad=auto_pad,
+                       p=p)
+
+  def test_lp2_pool_3d(self):
+    kernel_shape = [3, 3, 3]
+    strides = [2, 2, 2]
+    p = 2
+
+    input_shape = [10, 3, 23, 23, 23]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       p=p)
+
+  def test_lp2_pool_2d_pads(self):
+    kernel_shape = [3, 3]
+    strides = [2, 2]
+    p = 2
+    pads = [1, 1, 2, 2]
+
+    input_shape = [10, 3, 24, 24]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       pads=pads,
+                       p=p)
+
+  def test_lp2_pool_1d(self):
+    kernel_shape = [3]
+    strides = [2]
+    p = 2
+
+    input_shape = [10, 3, 23]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       p=p)
+
+  def test_lp3_pool_2d_pads(self):
+    kernel_shape = [3, 3]
+    strides = [2, 2]
+    p = 3
+    pads = [1, 1, 2, 2]
+
+    input_shape = [10, 3, 24, 24]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       pads=pads,
+                       p=p)
+
+  def test_lp3_pool_3d(self):
+    kernel_shape = [3, 3, 3]
+    strides = [2, 2, 2]
+    p = 3
+
+    input_shape = [10, 3, 23, 23, 23]
+    self._test_pooling(input_shape=input_shape,
+                       kernel_shape=kernel_shape,
+                       strides=strides,
+                       p=p)
 
   def test_mean_variance_normalization(self):
     if legacy_opset_pre_ver(9):


### PR DESCRIPTION
Implements LpPool by utilizing avg_pool:

    window_size = np.prod(ksize)

    input = tf.math.pow(input, self.p) * window_size
    pooled = tf.nn.avg_pool(input, ksize=ksize, strides=strides, padding=padding)
    pooled = tf.math.pow(pooled, 1.0 / self.p)