### PR TITLE
Add auto data type cast

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -33,6 +33,10 @@ Currently, the strict flag only affects the behavior of MaxPool and AveragePool 
 to see more conversion details or to WARNING to see less
 
 
+`auto_cast` : Whether to auto cast data types that might lose precision for the tensors
+with types not natively supported by Tensorflow, default is False
+
+
 _returns_:
 
 A TensorflowRep class object representing the ONNX model

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -28,6 +28,7 @@ More information: `onnx-tf convert -h`
 ```
 usage: onnx-tf [-h] --infile INFILE --outfile OUTFILE [--device DEVICE]
                [--strict STRICT] [--logging_level LOGGING_LEVEL]
+               [--auto_cast AUTO_CAST]
 
 This is the converter for converting protocol buffer between tf and onnx.
 
@@ -51,4 +52,9 @@ backend arguments (onnx -> tf):
                         The logging level, default is INFO. Change it to DEBUG
                         to see more conversion details or to WARNING to see
                         less (from onnx_tf.backend.prepare)
+  --auto_cast AUTO_CAST
+                        Whether to auto cast data types that might lose
+                        precision for the tensors with types not natively
+                        supported by Tensorflow, default is False (from
+                        onnx_tf.backend.prepare)
 ```

--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -2,7 +2,8 @@
 |||
 |-:|:-|
 |ONNX-Tensorflow Version|Master ( commit id: 8ec5d4d06005c7d075d477327827589b2e762f4f )|
-|ONNX Version|1.7.0|
+|ONNX-Tensorflow Version|Master ( commit id: db6f1e336af4dead4193f8fee4671497c1cc8159 )|
+|ONNX Version|Master ( commit id: 9c3f3734b669058374a8a23df96f948d3bbfe73b )|
 |Tensorflow Version|v2.2.0|
 
 Notes:
@@ -44,7 +45,7 @@ Notes:
 |ConvTranspose|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**11**:small_orange_diamond:|11:small_orange_diamond:|11:small_orange_diamond:|ConvTranspose|
 |Cos|-|-|-|-|-|-|**7**|7|7|7|7|7|7|Cos|
 |Cosh|-|-|-|-|-|-|-|-|**9**|9|9|9|9|Cosh|
-|CumSum|-|-|-|-|-|-|-|-|-|-|**11**:small_orange_diamond:|11:small_orange_diamond:|11:small_orange_diamond:|CumSum|
+|CumSum|-|-|-|-|-|-|-|-|-|-|**11**|11|11|CumSum|
 |DepthToSpace|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|DepthToSpace|
 |DequantizeLinear|-|-|-|-|-|-|-|-|-|**10**|10|10|**13**:small_red_triangle:|DequantizeLinear|
 |Det|-|-|-|-|-|-|-|-|-|-|**11**|11|11|Det|
@@ -53,7 +54,7 @@ Notes:
 |DynamicQuantizeLinear|-|-|-|-|-|-|-|-|-|-|**11**|11|11|DynamicQuantizeLinear|
 |Einsum|-|-|-|-|-|-|-|-|-|-|-|**12**:small_red_triangle:|12:small_red_triangle:|Einsum|
 |Elu|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|Elu|
-|Equal|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**7**:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|**11**:small_orange_diamond:|11:small_orange_diamond:|**13**:small_red_triangle:|Equal|
+|Equal|**1**|1|1|1|1|1|**7**|7|7|7|**11**|11|**13**|Equal|
 |Erf|-|-|-|-|-|-|-|-|**9**|9|9|9|**13**:small_red_triangle:|Erf|
 |Exp|**1**|1|1|1|1|**6**|6|6|6|6|6|6|**13**:small_red_triangle:|Exp|
 |Expand|-|-|-|-|-|-|-|**8**|8|8|8|8|**13**:small_red_triangle:|Expand|
@@ -186,15 +187,13 @@ Notes:
 2. Clip: Clip input in uint64 is not supported in Tensorflow.
 3. ConcatFromSequence: new_axis=1 not supported in Tensorflow.
 4. ConvTranspose: ConvTranspose with dilations != 1, or transposed convolution for 4D or higher are not supported in Tensorflow.
-5. CumSum: CumSum inputs in uint32/uint64 are not supported in Tensorflow.
-6. Equal: Equal inputs in uint16/uint32/uint64 are not supported in Tensorflow.
-7. GRU: GRU with clip or GRU with linear_before_reset, or GRU not using sigmoid for z and r, or GRU using Elu as the activation function with alpha != 1, or GRU using HardSigmoid as the activation function with alpha != 0.2 or beta != 0.5 are not supported in TensorFlow.
-8. LSTM: LSTM not using sigmoid for `f`, or LSTM not using the same activation for `g` and `h` are not supported in Tensorflow.
-9. MaxPool: MaxPoolWithArgmax with pad is None or incompatible mode, or MaxPoolWithArgmax with 4D or higher input, or MaxPoolWithArgmax with column major are not supported in Tensorflow.
-10. Mod: Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 are not supported in Tensorflow.
-11. OneHot: OneHot indices in uint16/uint32/uint64/int8/int16/float16/float/double, or OneHot depth in uint8/uint16/uint32/uint64/int8/int16/int64/float16/float/double are not supported in Tensorflow.
-12. RNN: RNN with clip is not supported in Tensorflow.
-13. Resize: Resize required 4D input in Tensorflow. For opset 11, only the following attributes and inputs conbination are supported in Tensorflow:
+5. GRU: GRU with clip or GRU with linear_before_reset, or GRU not using sigmoid for z and r, or GRU using Elu as the activation function with alpha != 1, or GRU using HardSigmoid as the activation function with alpha != 0.2 or beta != 0.5 are not supported in TensorFlow.
+6. LSTM: LSTM not using sigmoid for `f`, or LSTM not using the same activation for `g` and `h` are not supported in Tensorflow.
+7. MaxPool: MaxPoolWithArgmax with pad is None or incompatible mode, or MaxPoolWithArgmax with 4D or higher input, or MaxPoolWithArgmax with column major are not supported in Tensorflow.
+8. Mod: Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 are not supported in Tensorflow.
+9. OneHot: OneHot indices in uint16/uint32/uint64/int8/int16/float16/float/double, or OneHot depth in uint8/uint16/uint32/uint64/int8/int16/int64/float16/float/double are not supported in Tensorflow.
+10. RNN: RNN with clip is not supported in Tensorflow.
+11. Resize: Resize required 4D input in Tensorflow. For opset 11, only the following attributes and inputs conbination are supported in Tensorflow:
 	1. mode=nearest, coordinate_transformation_mode=align_corners, nearest_mode=round_prefer_ceil, can use scales(*) or sizes.
 	2. mode=nearest, coordinate_transformation_mode=asymmetric, nearest_mode=floor, can use scales(*) or sizes.
 	3. mode=nearest, coordinate_transformation_mode=tf_half_pixel_for_nn, nearest_mode=floor, can use scales(*) or sizes.
@@ -207,5 +206,5 @@ Notes:
 	10. mode=nearest, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, nearest_mode=round_prefer_ceil, can use scales or sizes.
 	11. mode=linear, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, can use scales or sizes.
 	- Note (*): The accuracy of your model will go down, if the height and the width of the new sizes(scales * origial sizes) are not in whole numbers.
-14. SplitToSequence: Scalar as the split input not supported.
-15. Upsample: Upsample required 4D input in Tensorflow.
+12. SplitToSequence: Scalar as the split input not supported.
+13. Upsample: Upsample required 4D input in Tensorflow.

--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -41,6 +41,7 @@ class TensorflowBackend(Backend):
               device='CPU',
               strict=True,
               logging_level='INFO',
+              auto_cast=False,
               **kwargs):
     """Prepare an ONNX model for Tensorflow Backend.
 
@@ -56,12 +57,15 @@ class TensorflowBackend(Backend):
       Currently, the strict flag only affects the behavior of MaxPool and AveragePool ops.
     :param logging_level: The logging level, default is INFO. Change it to DEBUG
       to see more conversion details or to WARNING to see less
+    :param auto_cast: Whether to auto cast data types that might lose precision for the tensors
+      with types not natively supported by Tensorflow, default is False
 
     :returns: A TensorflowRep class object representing the ONNX model
     """
     super(TensorflowBackend, cls).prepare(model, device, **kwargs)
     common.logger.setLevel(logging_level)
     common.logger.handlers[0].setLevel(logging_level)
+    common.sys_config.auto_cast=auto_cast
 
     return cls.onnx_model_to_tensorflow_rep(model, strict)
 

--- a/onnx_tf/common/data_type.py
+++ b/onnx_tf/common/data_type.py
@@ -5,6 +5,7 @@ from onnx import mapping
 from onnx import TensorProto
 import tensorflow as tf
 
+import onnx_tf.common as common
 
 def tf2onnx(dtype):
   if isinstance(dtype, Number):
@@ -24,6 +25,9 @@ def tf2onnx(dtype):
   # numpy string type desired.
   if tf_dype is tf.string:
     return TensorProto.STRING
+
+  if tf_dype is tf.bfloat16:
+    return TensorProto.BFLOAT16
 
   onnx_dtype = None
   try:
@@ -106,3 +110,14 @@ def is_safe_cast(from_dtype, to_dtype):
       tf.complex128: []
   }
   return to_dtype in safe_cast_map[from_dtype]
+
+
+def tf_to_np_str(from_type):
+  return mapping.TENSOR_TYPE_TO_NP_TYPE[int(tf2onnx(
+      from_type))].name if from_type != tf.bfloat16 else 'bfloat16'
+
+
+def tf_to_np_str_list(from_list):
+  return [
+      tf_to_np_str(from_list[i]) for i in range(len(from_list))
+  ]

--- a/onnx_tf/common/exception.py
+++ b/onnx_tf/common/exception.py
@@ -66,7 +66,22 @@ class ConstNotFoundException(CustomException):
     return self._message.format(name, op)
 
 
+class DtypeNotCastException(object):
+
+  def __init__(self):
+    super(DtypeNotCastException, self).__init__()
+    self._func = RuntimeError
+    self._message = "{} is not supported in Tensorflow. Please set auto_cast to True or change data type to one of the supported types in {}."
+
+  def __call__(self, op, supported_dtypes):
+    raise self._func(self.get_message(op, supported_dtypes))
+
+  def get_message(self, op, supported_dtypes):
+    return self._message.format(op, supported_dtypes)
+
+
 IGNORE_UNIMPLEMENTED = False
 OP_UNIMPLEMENTED_EXCEPT = OpUnimplementedException()
 OP_UNSUPPORTED_EXCEPT = OpUnsupportedException()
 CONST_NOT_FOUND_EXCEPT = ConstNotFoundException()
+DTYPE_NOT_CAST_EXCEPT = DtypeNotCastException()

--- a/onnx_tf/converter.py
+++ b/onnx_tf/converter.py
@@ -110,7 +110,8 @@ def parse_args(args):
                      [(backend.prepare, {
                          "device": {},
                          "strict": {},
-                         "logging_level": {}
+                         "logging_level": {},
+                         "auto_cast": {}
                      })])
 
   return parser.parse_args(args)

--- a/onnx_tf/handlers/backend/cumsum.py
+++ b/onnx_tf/handlers/backend/cumsum.py
@@ -1,40 +1,45 @@
 import tensorflow as tf
 
-from onnx_tf.common import exception
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
-from onnx_tf.handlers.handler import partial_support
-from onnx_tf.handlers.handler import ps_description
 from onnx_tf.handlers.handler import tf_func
+from onnx_tf.common import sys_config
+from onnx_tf.common import exception
+from onnx_tf.common import data_type
+#import onnx_tf.common.data_type as data_type
 
 
 @onnx_op("CumSum")
 @tf_func(tf.math.cumsum)
-@partial_support(True)
-@ps_description(
-    "CumSum inputs in uint32/uint64 " + "are not supported in Tensorflow."
-)
 class CumSum(BackendHandler):
+  cast_map = {tf.uint32: tf.int64}
+  cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+  supported_types = [tf.int32, tf.int64, tf.float32, tf.float64]
+
   @classmethod
   def args_check(cls, node, **kwargs):
-    supported_dtype = [
-        tf.bfloat16, tf.half, tf.float32, tf.float64, tf.uint8, tf.uint16,
-        tf.int8, tf.int16, tf.int32, tf.int64, tf.complex64, tf.complex128
-    ]
     x = kwargs["tensor_dict"][node.inputs[0]]
-    if x.dtype not in supported_dtype:
-      exception.OP_UNSUPPORTED_EXCEPT(
-          "CumSum input in " + str(x.dtype) + " which", "Tensorflow")
+
+    # throw an error if the data type is not natively supported by
+    # Tensorflow, cannot be safely cast, and auto-cast option is False
+    if x.dtype in cls.cast_map and cls.cast_map[x.dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "CumSum input " + node.inputs[0] + " with data type '" +
+          data_type.tf_to_np_str(x.dtype) + "'",
+          data_type.tf_to_np_str_list(cls.supported_types))
 
   @classmethod
   def version_11(cls, node, **kwargs):
-    tensor_dict = kwargs["tensor_dict"]
-    x = tensor_dict[node.inputs[0]]
+    x = kwargs["tensor_dict"][node.inputs[0]]
+
+    # handle data types that are not natively supported by Tensorflow
+    dtype = x.dtype
+    x = tf.cast(x, cls.cast_map[dtype]) if dtype in cls.cast_map else x
     inputs = [x]
 
     if len(node.inputs) > 1:
       # optional 0-D tensor, range [-rank(x), rank(x)-1]
-      axis = tensor_dict[node.inputs[1]]
+      axis = kwargs["tensor_dict"][node.inputs[1]]
       inputs.append(axis)
 
     attrs = {
@@ -42,4 +47,5 @@ class CumSum(BackendHandler):
         "reverse": bool(node.attrs.get("reverse", 0))
     }
 
-    return [cls.make_tensor_from_onnx_node(node, inputs=inputs, attrs=attrs)]
+    result = cls.make_tensor_from_onnx_node(node, inputs=inputs, attrs=attrs)
+    return [tf.cast(result, dtype) if dtype in cls.cast_map else result]

--- a/onnx_tf/handlers/backend/equal.py
+++ b/onnx_tf/handlers/backend/equal.py
@@ -1,33 +1,47 @@
 import tensorflow as tf
 
-from onnx_tf.common import exception
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
-from onnx_tf.handlers.handler import partial_support
-from onnx_tf.handlers.handler import ps_description
 from .control_flow_mixin import ComparisonMixin
-
+from onnx_tf.common import sys_config
+from onnx_tf.common import exception
+import onnx_tf.common.data_type as data_type
 
 @onnx_op("Equal")
 @tf_func(tf.equal)
-@partial_support(True)
-@ps_description(
-    "Equal inputs in uint16/uint32/uint64 " + "are not supported in Tensorflow."
-)
 class Equal(ComparisonMixin, BackendHandler):
+  cast_map = {tf.uint16: tf.int32, tf.uint32: tf.int64}
+  cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+  supported_types = [
+      tf.bool, tf.uint8, tf.int8, tf.int16, tf.int32, tf.int64, tf.float16,
+      tf.float32, tf.float64, tf.bfloat16
+  ]
 
   @classmethod
   def args_check(cls, node, **kwargs):
-    supported_dtype = [
-        tf.bfloat16, tf.half, tf.float32, tf.float64, tf.uint8, tf.int8,
-        tf.int16, tf.int32, tf.int64, tf.complex64, tf.quint8, tf.qint8,
-        tf.qint32, tf.string, tf.bool, tf.complex128
-    ]
     x = kwargs["tensor_dict"][node.inputs[0]]
-    if x.dtype not in supported_dtype:
-      exception.OP_UNSUPPORTED_EXCEPT(
-          "Equal inputs in " + str(x.dtype) + " which", "Tensorflow")
+
+    # throw an error if the data type is not natively supported by
+    # Tensorflow, cannot be safely cast, and auto_cast option is False
+    if x.dtype in cls.cast_map and cls.cast_map[x.dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "Equal input " + node.inputs[0] + " with data type '" +
+          data_type.tf_to_np_str(x.dtype) + "'",
+          data_type.tf_to_np_str_list(cls.supported_types))
+
+  @classmethod
+  def _common(cls, node, **kwargs):
+
+    def dtype_cast(x, y):
+      x = tf.cast(x, cls.cast_map[x.dtype]) if x.dtype in cls.cast_map else x
+      y = tf.cast(y, cls.cast_map[y.dtype]) if y.dtype in cls.cast_map else y
+      return x, y
+
+    # handle data types that are not natively supported by Tensorflow
+    x, y = dtype_cast(kwargs["tensor_dict"][node.inputs[0]],
+                      kwargs["tensor_dict"][node.inputs[1]])
+    return [cls.make_tensor_from_onnx_node(node, inputs=[x, y])]
 
   @classmethod
   def version_1(cls, node, **kwargs):
@@ -35,8 +49,12 @@ class Equal(ComparisonMixin, BackendHandler):
 
   @classmethod
   def version_7(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    return cls._common(node, **kwargs)
 
   @classmethod
   def version_11(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
+    return cls._common(node, **kwargs)

--- a/onnx_tf/handlers/backend/pow.py
+++ b/onnx_tf/handlers/backend/pow.py
@@ -5,31 +5,46 @@ from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
 from .math_mixin import BasicMathMixin
 from onnx_tf.common import sys_config
+from onnx_tf.common import exception
 from onnx_tf.common import data_type
 
 
 @onnx_op("Pow")
 @tf_func(tf.pow)
 class Pow(BasicMathMixin, BackendHandler):
+  x_cast_map = {tf.bfloat16: tf.float32}
+  y_cast_map = {
+      tf.uint8: tf.int16,
+      tf.uint16: tf.int32,
+      tf.uint32: tf.int64,
+      tf.int8: tf.int16,
+      tf.int16: tf.int32
+  }
+  y_cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+  supported_types = [tf.int32, tf.int64, tf.float16, tf.float32, tf.float64]
+
+  @classmethod
+  def args_check(cls, node, **kwargs):
+    y = kwargs["tensor_dict"][node.inputs[1]]
+
+    # throw an error if the data type is not natively supported by
+    # Tensorflow, cannot be safely cast, and auto-cast option is False
+    if y.dtype in cls.y_cast_map and cls.y_cast_map[y.dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "Pow input " + node.inputs[1] + " with data type '" +
+          data_type.tf_to_np_str(y.dtype) + "'",
+          data_type.tf_to_np_str_list(cls.supported_types))
 
   @classmethod
   def _common(cls, node, **kwargs):
 
     def x_cast(x):
       # Cast input to a data type that is supported by Tensorflow Pow
-      cast_map = {tf.bfloat16: tf.float32}
-      x = tf.cast(x, cast_map[x.dtype]) if x.dtype in cast_map else x
-      return x
+      return tf.cast(x, cls.x_cast_map[x.dtype])
 
     def y_cast(y, to_dtype):
-      # Cast exponent to the input data type when it is safe or auto cast is
-      # set to True. Otherwise an error will occure due to the potential issue
-      # in loss of data.
-      if sys_config.auto_cast or data_type.is_safe_cast(y.dtype, to_dtype):
-        return tf.cast(y, to_dtype)
-      else:
-        raise RuntimeError(
-            "Exponent dtype cannot be safely cast to input dtype.")
+      # Cast exponent to the input data type
+      return tf.cast(y, to_dtype)
 
     x = kwargs["tensor_dict"][node.inputs[0]]
     y = kwargs["tensor_dict"][node.inputs[1]]
@@ -37,15 +52,13 @@ class Pow(BasicMathMixin, BackendHandler):
     y_dtype = y.dtype
 
     # Tensorflow Pow supports limited data types
-    supported_types = [tf.float16, tf.float32, tf.float64, tf.int32, tf.int64]
-    need_cast = x_dtype not in supported_types
-    x = x_cast(x) if need_cast else x
+    x = x_cast(x) if x_dtype in cls.x_cast_map else x
     y = y_cast(y, x.dtype) if y_dtype != x.dtype else y
 
     inputs = [x, y]
     result = cls.make_tensor_from_onnx_node(node, inputs=inputs)
 
-    return [tf.cast(result, x_dtype) if need_cast else result]
+    return [tf.cast(result, x_dtype) if x_dtype in cls.x_cast_map else result]
 
   @classmethod
   def version_1(cls, node, **kwargs):

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -44,7 +44,7 @@ backend_opset_version = {
     'DynamicQuantizeLinear': [11],
     'Einsum': [],
     'Elu': [1, 6],
-    'Equal': [1, 7, 11],
+    'Equal': [1, 7, 11, 13],
     'Erf': [9],
     'Exp': [1, 6],
     'Expand': [8],
@@ -196,9 +196,6 @@ backend_partial_support = {
     'ConvTranspose': 'ConvTranspose with dilations != 1, or transposed '
                      'convolution for 4D or higher are not supported in '
                      'Tensorflow.',
-    'CumSum': 'CumSum inputs in uint32/uint64 are not supported in Tensorflow.',
-    'Equal': 'Equal inputs in uint16/uint32/uint64 are not supported in '
-             'Tensorflow.',
     'GRU': 'GRU with clip or GRU with linear_before_reset, or GRU not using '
            'sigmoid for z and r, or GRU using Elu as the activation function '
            'with alpha != 1, or GRU using HardSigmoid as the activation '

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -579,6 +579,12 @@ class TestNode(unittest.TestCase):
     y = np.cumsum(x, axis).astype(np.int32)
     output = run_node(node_def, [x, axis])
     np.testing.assert_almost_equal(output["y"], y)
+    # test data types that are not natively supported by Tensorflow
+    x = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.uint32)
+    y = np.cumsum(x, axis).astype(np.uint32)
+    output = run_node(node_def, [x, axis])
+    np.testing.assert_almost_equal(output["y"], y)
+
 
   def test_depth_to_space(self):
     node_def = helper.make_node("DepthToSpace", ["X"], ["Y"], blocksize=2)
@@ -673,6 +679,16 @@ class TestNode(unittest.TestCase):
     output = run_node(node_def, [x, y])
     np.testing.assert_equal(output["Z"], np.equal(x,
                                                   np.reshape(y, [1, 3, 3, 1])))
+    # test data types that are not natively supported by Tensorflow
+    x = np.arange(8).reshape((2, 2, 2)).astype(np.uint16)
+    y = np.arange(8).reshape((2, 2, 2)).astype(np.uint16)
+    output = run_node(node_def, [x, y])
+    np.testing.assert_equal(output["Z"], np.equal(x, y))
+
+    x = np.arange(8).reshape((2, 2, 2)).astype(np.uint64)
+    y = np.arange(8).reshape((2, 2, 2)).astype(np.uint64)
+    with np.testing.assert_raises(RuntimeError):
+      output = run_node(node_def, [x, y])
 
   def test_erf(self):
     if legacy_opset_pre_ver(9):

--- a/test/backend/test_onnx_backend.py
+++ b/test/backend/test_onnx_backend.py
@@ -113,12 +113,8 @@ backend_test.exclude(r'test_sequence_model5_[a-z,_]*')
 # Fails rounding tolerance
 backend_test.exclude(r'test_gru_seq_length_[a-z,_]*')
 
-# TF pow does not support mixing float/int types
-backend_test.exclude(r'test_pow_types_float[0-9]+_[u]?int[0-9]+_[a-z,_]*')
-backend_test.exclude(r'test_pow_types_[u]?int[0-9]+_float[0-9]+_[a-z,_]*')
-# not sure where these are defined...
-backend_test.exclude(r'test_pow_types_int_[a-z,_]*')
-backend_test.exclude(r'test_pow_types_float_[a-z,_]*')
+# TF pow does not support uint64 when auto-cast is False (default)
+backend_test.exclude(r'test_pow_types_float[0-9]+_uint64+_[a-z,_]*')
 
 # import all test cases at global scope to make them visible to python.unittest
 globals().update(backend_test.enable_report().test_cases)


### PR DESCRIPTION
Add auto data type cast to support the data types that are
not natively supported by Tensorflow.

This PR adds the following
1. a common sys_config so the auto_cast option can be accessed
everywhere
2. additional data type support for equal operator
3. additional data type support for cumsum operator
4. unit tests for these data types
5. a new parameter auto-cast for CLI and prepare