### PR TITLE
Add Pow support for opset 12 and 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 *.cf
 *.tf
+
+# generated files
+onnx_tf/version.py

--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,8 +1,8 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: ee0e90567b9772fab4974607bcc64fe7d410865b )|
-|ONNX Version|Master ( commit id: cc2230603422bae893d5bc900d2d773ab34400a4 )|
+|ONNX-Tensorflow Version|Master ( commit id: 8ec5d4d06005c7d075d477327827589b2e762f4f )|
+|ONNX Version|1.7.0|
 |Tensorflow Version|v2.2.0|
 
 Notes:
@@ -108,7 +108,7 @@ Notes:
 |Or|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|Or|
 |PRelu|**1**|1|1|1|1|**6**|**7**|7|**9**|9|9|9|9|PRelu|
 |Pad|**1**|**2**|2|2|2|2|2|2|2|2|**11**|11|**13**:small_red_triangle:|Pad|
-|Pow|**1**|1|1|1|1|1|**7**|7|7|7|7|**12**:small_red_triangle:|**13**:small_red_triangle:|Pow|
+|Pow|**1**|1|1|1|1|1|**7**|7|7|7|7|**12**|**13**|Pow|
 |QLinearConv|-|-|-|-|-|-|-|-|-|**10**|10|10|10|QLinearConv|
 |QLinearMatMul|-|-|-|-|-|-|-|-|-|**10**|10|10|10|QLinearMatMul|
 |QuantizeLinear|-|-|-|-|-|-|-|-|-|**10**|10|10|**13**:small_red_triangle:|QuantizeLinear|
@@ -179,7 +179,7 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|9|Where|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|Xor|
 
-ONNX-TF Supported Operators / ONNX Operators: 83 / 162
+ONNX-TF Supported Operators / ONNX Operators: 84 / 162
 
 Notes:
 1. Cast: Cast string to data types other than float32/float64/int32/int64 is not supported in Tensorflow

--- a/onnx_tf/common/__init__.py
+++ b/onnx_tf/common/__init__.py
@@ -23,6 +23,11 @@ formatter = logging.Formatter(
 console.setFormatter(formatter)
 logger.addHandler(console)
 
+class SysConfig:
+  def __init__(self):
+    self.auto_cast = False
+
+sys_config = SysConfig()
 
 class Deprecated:
   """Add deprecated message when function is called.

--- a/onnx_tf/common/data_type.py
+++ b/onnx_tf/common/data_type.py
@@ -74,3 +74,35 @@ def any_dtype_to_onnx_dtype(np_dtype=None, tf_dtype=None, onnx_dtype=None):
     onnx_dtype = tf2onnx(tf_dtype)
 
   return onnx_dtype
+
+
+def is_safe_cast(from_dtype, to_dtype):
+  safe_cast_map = {
+      tf.bfloat16: [tf.float32, tf.float64, tf.complex64, tf.complex128],
+      tf.float16: [tf.float32, tf.float64, tf.complex64, tf.complex128],
+      tf.float32: [tf.float64, tf.complex128],
+      tf.float64: [tf.complex128],
+      tf.int8: [
+          tf.bfloat16, tf.float16, tf.float32, tf.float64, tf.int16, tf.int32,
+          tf.int64, tf.complex64, tf.complex128
+      ],
+      tf.int16: [
+          tf.float32, tf.float64, tf.int32, tf.int64, tf.complex64,
+          tf.complex128
+      ],
+      tf.int32: [tf.float64, tf.int64, tf.complex128],
+      tf.int64: [],
+      tf.uint8: [
+          tf.float16, tf.float32, tf.float64, tf.int16, tf.int32, tf.int64,
+          tf.complex64, tf.complex128
+      ],
+      tf.uint16: [
+          tf.float32, tf.float64, tf.int32, tf.int64, tf.complex64,
+          tf.complex128
+      ],
+      tf.uint32: [tf.float64, tf.int64, tf.complex128],
+      tf.unit64: [],
+      tf.complex64: [tf.complex128],
+      tf.complex128: []
+  }
+  return to_dtype in safe_cast_map[from_dtype]

--- a/onnx_tf/handlers/backend/pow.py
+++ b/onnx_tf/handlers/backend/pow.py
@@ -4,6 +4,8 @@ from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
 from .math_mixin import BasicMathMixin
+from onnx_tf.common import sys_config
+from onnx_tf.common import data_type
 
 
 @onnx_op("Pow")
@@ -11,9 +13,52 @@ from .math_mixin import BasicMathMixin
 class Pow(BasicMathMixin, BackendHandler):
 
   @classmethod
+  def _common(cls, node, **kwargs):
+
+    def x_cast(x):
+      # Cast input to a data type that is supported by Tensorflow Pow
+      cast_map = {tf.bfloat16: tf.float32}
+      x = tf.cast(x, cast_map[x.dtype]) if x.dtype in cast_map else x
+      return x
+
+    def y_cast(y, to_dtype):
+      # Cast exponent to the input data type when it is safe or auto cast is
+      # set to True. Otherwise an error will occure due to the potential issue
+      # in loss of data.
+      if sys_config.auto_cast or data_type.is_safe_cast(y.dtype, to_dtype):
+        return tf.cast(y, to_dtype)
+      else:
+        raise RuntimeError(
+            "Exponent dtype cannot be safely cast to input dtype.")
+
+    x = kwargs["tensor_dict"][node.inputs[0]]
+    y = kwargs["tensor_dict"][node.inputs[1]]
+    x_dtype = x.dtype
+    y_dtype = y.dtype
+
+    # Tensorflow Pow supports limited data types
+    supported_types = [tf.float16, tf.float32, tf.float64, tf.int32, tf.int64]
+    need_cast = x_dtype not in supported_types
+    x = x_cast(x) if need_cast else x
+    y = y_cast(y, x.dtype) if y_dtype != x.dtype else y
+
+    inputs = [x, y]
+    result = cls.make_tensor_from_onnx_node(node, inputs=inputs)
+
+    return [tf.cast(result, x_dtype) if need_cast else result]
+
+  @classmethod
   def version_1(cls, node, **kwargs):
     return cls.limited_broadcast(node, **kwargs)
 
   @classmethod
   def version_7(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_12(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
+    return cls._common(node, **kwargs)

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -110,7 +110,7 @@ backend_opset_version = {
     'Or': [1, 7],
     'PRelu': [1, 6, 7, 9],
     'Pad': [1, 2, 11],
-    'Pow': [1, 7],
+    'Pow': [1, 7, 12, 13],
     'QLinearConv': [10],
     'QLinearMatMul': [10],
     'QuantizeLinear': [10],

--- a/test/backend/test_model.py
+++ b/test/backend/test_model.py
@@ -257,5 +257,25 @@ class TestModel(unittest.TestCase):
     output = tf_rep.run({"X": X, "Y": Y})
     np.testing.assert_almost_equal(output["W2"], W_ref)
 
+  def test_pow_bfloat16(self):
+    X1 = np.array([1, 2, 3]).astype(np.float32)
+    X2 = np.array([2, 3, 4]).astype(np.float32)
+    Y_ref = np.power(X1, X2).astype(X1.dtype)
+
+    graph_def = helper.make_graph(
+        [
+            helper.make_node("Cast", ["X1"], ["C1"], to=TensorProto.BFLOAT16),
+            helper.make_node("Pow", ["C1", "X2"], ["Y"])
+        ],
+        name="test",
+        inputs=[helper.make_tensor_value_info("X1", TensorProto.FLOAT, [3]),
+            helper.make_tensor_value_info("X2", TensorProto.FLOAT, [3])],
+        outputs=[
+            helper.make_tensor_value_info("Y", TensorProto.BFLOAT16, [3])
+        ])
+    tf_rep = prepare(helper.make_model(graph_def))
+    output = tf_rep.run({"X1": X1, "X2": X2})
+    np.testing.assert_almost_equal(output.Y, Y_ref)
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Add Pow support for opset 12 and 13 including
1. add data type cast whenever needed
2. add support when input and exponent have different types
3. add test case for bfloat16 in test_model.py

Also updated .gitignore so the generated version.py is not
tracked by git