### PR TITLE
Add model stepping test for Mnist

### DIFF
--- a/example/test_mnist_onnxruntime_stepping.py
+++ b/example/test_mnist_onnxruntime_stepping.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import numpy as np
+
+import onnx
+from onnx import helper
+import tensorflow as tf
+import onnxruntime.backend as ort
+
+import onnx_tf.backend as otf
+from onnx_tf.common import data_type
+
+def find_between(s, first, last):
+  try:
+    start = s.index(first)
+    end = s.index(last) + len(last)
+    return s[start:end]
+  except ValueError:
+    return ""
+
+class TestMnistModel(unittest.TestCase):
+  # make sure the onnx file path is correct
+  model_path = "../../onnx_models/mnist/model.onnx"
+
+  def test(self):
+    _model = onnx.load(self.model_path)
+    print("Total node count in model: ", len(_model.graph.node))
+
+    # load tensor_dict using onnx_tf for output dtype and shape
+    tensor_dict = otf.prepare(_model).tensor_dict
+
+    more_outputs = []
+    output_to_check = []
+    for node in _model.graph.node:
+      # add the first output of each node to the model output
+      output_tensor = None
+      for i in range(len(_model.graph.value_info)):
+        if _model.graph.value_info[i].name == node.output[0]:
+           output_tensor = _model.graph.value_info[i]
+
+      for i in range(len(_model.graph.initializer)):
+        if _model.graph.initializer[i].name == node.output[0]:
+           output_tensor = _model.graph.initializer[i]
+
+      # assue the first output is a tensor
+      tensor = tensor_dict[node.output[0]]
+      output_tensor = helper.make_tensor_value_info(node.output[0],
+                      data_type.tf2onnx(tensor.dtype),
+                      tensor.shape) if output_tensor is None else output_tensor
+      more_outputs.append(output_tensor)
+      output_to_check.append(node.output[0])
+    _model.graph.output.extend(more_outputs)
+
+    tf_rep = otf.prepare(_model)
+    rt_rep = ort.prepare(_model)
+
+    # prepare input data
+    mnist = tf.keras.datasets.mnist
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    x_train, x_test = x_train / 255.0, x_test / 255.0
+    sample = x_test[:1].reshape(1,1,28,28).astype(np.float32)
+
+    inputs = [sample]
+    my_out = tf_rep.run(inputs)
+    rt_out = rt_rep.run(inputs)
+
+    for op in output_to_check:
+      for i in range(len(my_out)):
+        # find the index of output in the list
+        if my_out[op] is my_out[i]:
+
+          try:
+            np.savetxt(
+              op.replace("/", "__") + ".rt", rt_out[i].flatten(), delimiter='\t')
+            np.savetxt(
+              op.replace("/", "__") + ".tf", my_out[i].flatten(), delimiter='\t')
+            np.testing.assert_allclose(my_out[i], rt_out[i], rtol=1e-2)
+            print(op, "results of this layer are correct within tolerence.")
+          except Exception as e:
+            np.set_printoptions(threshold=np.inf)
+            mismatch_percent = (find_between(str(e), "(mismatch", "%)"))
+            print(op, "mismatch with percentage {} %".format(mismatch_percent))
+
+
+if __name__ == '__main__':
+  unittest.main()
+  pass

--- a/example/test_mnist_onnxruntime_stepping.py
+++ b/example/test_mnist_onnxruntime_stepping.py
@@ -8,11 +8,13 @@ import numpy as np
 
 import onnx
 from onnx import helper
+from onnx import TensorProto
 import tensorflow as tf
 import onnxruntime.backend as ort
 
 import onnx_tf.backend as otf
 from onnx_tf.common import data_type
+
 
 def find_between(s, first, last):
   try:
@@ -22,17 +24,27 @@ def find_between(s, first, last):
   except ValueError:
     return ""
 
+
 class TestMnistModel(unittest.TestCase):
-  # make sure the onnx file path is correct
-  model_path = "../../onnx_models/mnist/model.onnx"
+  # Make sure the onnx file path is correct, assuming copied to the
+  # current directory
+  model_path = 'mnist-8.onnx'
 
   def test(self):
     _model = onnx.load(self.model_path)
     print("Total node count in model: ", len(_model.graph.node))
 
-    # load tensor_dict using onnx_tf for output dtype and shape
-    tensor_dict = otf.prepare(_model).tensor_dict
-
+    # The input tensors could be provided as constants
+    # The example below illustrates such a dictionary could be
+    # provided for models with unknown input shapes. Since
+    # mnist has known input shape, we don't provide input tensors.
+    # input_tensors = {'Input3': tf.constant(0, dtype = tf.float32,
+    #                    name='Input3',
+    #                    shape=[1, 1, 28, 28])}
+    input_tensors = {}
+    tensor_dict = otf.prepare(_model,
+                              gen_tensor_dict=True,
+                              input_tensor_dict=input_tensors).tensor_dict
     more_outputs = []
     output_to_check = []
     for node in _model.graph.node:
@@ -40,17 +52,17 @@ class TestMnistModel(unittest.TestCase):
       output_tensor = None
       for i in range(len(_model.graph.value_info)):
         if _model.graph.value_info[i].name == node.output[0]:
-           output_tensor = _model.graph.value_info[i]
+          output_tensor = _model.graph.value_info[i]
 
       for i in range(len(_model.graph.initializer)):
         if _model.graph.initializer[i].name == node.output[0]:
-           output_tensor = _model.graph.initializer[i]
+          output_tensor = _model.graph.initializer[i]
 
-      # assue the first output is a tensor
+      # assume the first output is a tensor
       tensor = tensor_dict[node.output[0]]
-      output_tensor = helper.make_tensor_value_info(node.output[0],
-                      data_type.tf2onnx(tensor.dtype),
-                      tensor.shape) if output_tensor is None else output_tensor
+      output_tensor = helper.make_tensor_value_info(
+          node.output[0], data_type.tf2onnx(tensor.dtype),
+          tensor.shape) if output_tensor is None else output_tensor
       more_outputs.append(output_tensor)
       output_to_check.append(node.output[0])
     _model.graph.output.extend(more_outputs)
@@ -62,7 +74,7 @@ class TestMnistModel(unittest.TestCase):
     mnist = tf.keras.datasets.mnist
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
     x_train, x_test = x_train / 255.0, x_test / 255.0
-    sample = x_test[:1].reshape(1,1,28,28).astype(np.float32)
+    sample = x_test[:1].reshape(1, 1, 28, 28).astype(np.float32)
 
     inputs = [sample]
     my_out = tf_rep.run(inputs)
@@ -74,10 +86,12 @@ class TestMnistModel(unittest.TestCase):
         if my_out[op] is my_out[i]:
 
           try:
-            np.savetxt(
-              op.replace("/", "__") + ".rt", rt_out[i].flatten(), delimiter='\t')
-            np.savetxt(
-              op.replace("/", "__") + ".tf", my_out[i].flatten(), delimiter='\t')
+            np.savetxt(op.replace("/", "__") + ".rt",
+                       rt_out[i].flatten(),
+                       delimiter='\t')
+            np.savetxt(op.replace("/", "__") + ".tf",
+                       my_out[i].flatten(),
+                       delimiter='\t')
             np.testing.assert_allclose(my_out[i], rt_out[i], rtol=1e-2)
             print(op, "results of this layer are correct within tolerence.")
           except Exception as e:

--- a/onnx_tf/backend_rep.py
+++ b/onnx_tf/backend_rep.py
@@ -16,6 +16,7 @@ class TensorflowRep(BackendRep):
     self._inputs = inputs or []
     self._outputs = outputs or []
     self._tensor_dict = tensor_dict or {}
+    self._tf_module = None
 
   @property
   def graph(self):
@@ -48,6 +49,14 @@ class TensorflowRep(BackendRep):
   @tensor_dict.setter
   def tensor_dict(self, tensor_dict):
     self._tensor_dict = tensor_dict
+
+  @property
+  def tf_module(self):
+    return self._tf_module
+
+  @tf_module.setter
+  def tf_module(self, tf_module):
+    self._tf_module = tf_module
 
   def run(self, inputs, **kwargs):
     """ Run TensorflowRep.

--- a/onnx_tf/backend_tf_module.py
+++ b/onnx_tf/backend_tf_module.py
@@ -1,6 +1,7 @@
 import tensorflow as tf
 from onnx_tf.pb_wrapper import OnnxNode
 
+
 class BackendTFModule(tf.Module):
 
   def __init__(self, handlers, opset, strict, graph_def, backend):
@@ -11,6 +12,22 @@ class BackendTFModule(tf.Module):
     self.graph_def = graph_def
     self.backend = backend
     self.outputs = []
+
+  @tf.function
+  def gen_tensor_dict(self, input_dict_items):
+    tensor_dict = dict(input_dict_items)
+
+    for node in self.graph_def.node:
+      onnx_node = OnnxNode(node)
+      output_ops = self.backend._onnx_node_to_tensorflow_op(onnx_node,
+                                                            tensor_dict,
+                                                            self.handlers,
+                                                            opset=self.opset,
+                                                            strict=self.strict)
+      curr_node_output_map = dict(zip(onnx_node.outputs, output_ops))
+      tensor_dict.update(curr_node_output_map)
+
+    return tensor_dict
 
   @tf.function
   def __call__(self, **kwargs):
@@ -26,8 +43,11 @@ class BackendTFModule(tf.Module):
 
     for node in self.graph_def.node:
       onnx_node = OnnxNode(node)
-      output_ops = self.backend._onnx_node_to_tensorflow_op(
-          onnx_node, tensor_dict, self.handlers, opset=self.opset, strict=self.strict)
+      output_ops = self.backend._onnx_node_to_tensorflow_op(onnx_node,
+                                                            tensor_dict,
+                                                            self.handlers,
+                                                            opset=self.opset,
+                                                            strict=self.strict)
       curr_node_output_map = dict(zip(onnx_node.outputs, output_ops))
       tensor_dict.update(curr_node_output_map)
 


### PR DESCRIPTION
Add model stepping test for Mnist using ONNX runtime. The
assumption is that ONNX runtime is installed and the mnist model
from ONNX model zoo is downloaded.