### PR TITLE
Dynamic shape support for ConvTranspose

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -26,7 +26,7 @@ optional arguments:
 
 More information: `onnx-tf convert -h`
 ```
-usage: onnx-tf [-h] --infile INFILE --outfile OUTFILE [--device DEVICE]
+usage: onnx-tf [-h] --infile INFILE --outdir OUTDIR [--device DEVICE]
                [--strict STRICT] [--logging_level LOGGING_LEVEL]
                [--auto_cast AUTO_CAST]
 
@@ -36,8 +36,8 @@ optional arguments:
   -h, --help            show this help message and exit
   --infile INFILE, -i INFILE
                         Input file path.
-  --outfile OUTFILE, -o OUTFILE
-                        Output file path.
+  --outdir OUTDIR, -o OUTDIR
+                        Output directory.
 
 backend arguments (onnx -> tf):
   --device DEVICE       The device to execute this model on. (from

--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,9 +1,9 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: 1f3f6b8cac846ddf6d8d510ce461ced8fbb7b676 )|
+|ONNX-Tensorflow Version|Master ( commit id: 626b4718728f245b325c56046d9b3a01e9d0b0bf )|
 |ONNX Version|Master ( commit id: b2ed660d0a065b8346816f2c3a95d79ca79b88c9 )|
-|Tensorflow Version|v2.3.0|
+|Tensorflow Version|v2.3.1|
 
 Notes:
 * Values that are new or updated from a previous opset version are in bold.
@@ -179,7 +179,7 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|9|Where|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|Xor|
 
-ONNX-TF Supported Operators / ONNX Operators: 96 / 162
+ONNX-TF Supported Operators / ONNX Operators: 100 / 162
 
 Notes:
 1. Cast: Cast string to data types other than float32/float64/int32/int64 is not supported in Tensorflow

--- a/onnx_tf/common/tf_helper.py
+++ b/onnx_tf/common/tf_helper.py
@@ -2,21 +2,25 @@ import tensorflow as tf
 import numpy as np
 
 
-def tf_shape(tensor):
-    """
+def tf_shape(tensor, dtype=tf.int64):
+  """
         Helper function returning the shape of a Tensor.
         The function will check for fully defined shape and will return
         numpy array or if the shape is not fully defined will use tf.shape()
         to return the shape as a Tensor.
-    """
-    if tensor.shape.is_fully_defined():
-        return np.array(tensor.shape.as_list(), dtype=np.int64)
-    else:
-        return tf.shape(tensor, out_type=tf.int64)
+
+        :param tensor: A Tensor
+        :param dtype: (Optional) The output dtype (tf.int32 or tf.int64).
+                      Defaults to tf.int64.
+  """
+  if tensor.shape.is_fully_defined():
+    return np.array(tensor.shape.as_list(), dtype=dtype.as_numpy_dtype)
+  else:
+    return tf.shape(tensor, out_type=dtype)
 
 
 def tf_product(a, b):
-    """
+  """
         Calculates the cartesian product of two column vectors a and b
 
         Example:
@@ -34,12 +38,12 @@ def tf_product(a, b):
                   [2 1]
                   [3 0]
                   [3 1]]
-    """
-    tile_a = tf.tile(a, [1, tf.shape(b)[0]])
-    tile_a = tf.expand_dims(tile_a, 2)
-    tile_a = tf.reshape(tile_a, [-1, 1])
+  """
+  tile_a = tf.tile(a, [1, tf.shape(b)[0]])
+  tile_a = tf.expand_dims(tile_a, 2)
+  tile_a = tf.reshape(tile_a, [-1, 1])
 
-    b = tf.tile(b, [tf.shape(a)[0], 1])
-    b = tf.concat([tile_a, b], axis=1)
+  b = tf.tile(b, [tf.shape(a)[0], 1])
+  b = tf.concat([tile_a, b], axis=1)
 
-    return b
+  return b

--- a/onnx_tf/converter.py
+++ b/onnx_tf/converter.py
@@ -93,7 +93,7 @@ def parse_args(args):
   # required two args, source and destination path
   parser.add_argument("--infile", "-i", help="Input file path.", required=True)
   parser.add_argument(
-      "--outfile", "-o", help="Output file path.", required=True)
+      "--outdir", "-o", help="Output directory.", required=True)
 
   def add_argument_group(parser, group_name, funcs):
     group = parser.add_argument_group(group_name)
@@ -114,12 +114,12 @@ def parse_args(args):
   return parser.parse_args(args)
 
 
-def convert(infile, outfile, **kwargs):
+def convert(infile, outdir, **kwargs):
   """Convert pb.
 
   Args:
     infile: Input path.
-    outfile: Output path.
+    outdir: Output path.
     **kwargs: Other args for converting.
 
   Returns:
@@ -132,5 +132,5 @@ def convert(infile, outfile, **kwargs):
   common.logger.info("Start converting onnx pb to tf pb:")
   onnx_model = onnx.load(infile)
   tf_rep = backend.prepare(onnx_model, **kwargs)
-  tf_rep.export_graph(outfile)
+  tf_rep.export_graph(outdir)
   common.logger.info("Converting completes successfully.")

--- a/onnx_tf/handlers/backend/conv_mixin.py
+++ b/onnx_tf/handlers/backend/conv_mixin.py
@@ -4,6 +4,7 @@ from onnx_tf.common import get_data_format
 from onnx_tf.common import get_perm_from_formats
 from onnx_tf.common import supports_device
 from onnx_tf.common import exception
+from onnx_tf.common.tf_helper import tf_shape
 from .broadcast_mixin import BroadcastMixin
 from .pad_mixin import PadMixin
 
@@ -27,7 +28,7 @@ class ConvMixin(BroadcastMixin):
     """
     x = input_dict[node.inputs[0]]
     x_rank = len(x.get_shape())
-    x_shape = x.get_shape().as_list()
+    x_shape = tf_shape(x, tf.int32)
     spatial_size = x_rank - 2
 
     support_cuda = supports_device("CUDA")
@@ -112,7 +113,7 @@ class ConvMixin(BroadcastMixin):
         x_spatial_shape = [
             x_shape[storage_format.find(d)] for d in spatial_format
         ]
-        weights_shape = weights.get_shape().as_list()
+        weights_shape = tf_shape(weights, tf.int32)
         output_shape = node.attrs.get("output_shape", None)
         conv_output_shape = [x_shape[storage_format.find("N")]]
 
@@ -130,16 +131,6 @@ class ConvMixin(BroadcastMixin):
                 for i, s in enumerate(output_shape[-2:])
             ]
           conv_output_shape.insert(compute_c_idx, weights_shape[-2])
-
-          def handle_dynamic_batch_size(output_shape, batch_idx):
-            output_shape[batch_idx] = tf.shape(x)[batch_idx]
-            return tf.stack(output_shape)
-
-          # process dynamic batch size
-          if conv_output_shape[storage_format.find("N")] is None:
-            batch_idx = storage_format.find("N")
-            conv_output_shape = handle_dynamic_batch_size(conv_output_shape,
-                    batch_idx)
 
           # make strides to match input rank
           strides_full = [1] + strides
@@ -174,19 +165,17 @@ class ConvMixin(BroadcastMixin):
             conv_rs = tf.pad(conv_rs, output_padding)
 
           # remove pads set in pads attr
-          conv_rs_shape = conv_rs.get_shape().as_list()
+          conv_rs_shape = tf_shape(conv_rs, tf.int32)
+          conv_rs_shape_list = [
+              conv_rs_shape[i] for i in range(conv_rs.shape.rank)
+          ]
           begin = [0] + pads[:spatial_size]
           begin.insert(compute_c_idx, 0)
           size = [
               s if d in ["N", "C"] else s - pads[spatial_format.find(d)] -
               pads[spatial_format.find(d) + spatial_size]
-              for d, s in zip(compute_format, conv_rs_shape)
+              for d, s in zip(compute_format, conv_rs_shape_list)
           ]
-
-          # process dynamic batch size
-          if size[compute_format.find("N")] is None:
-            batch_idx = compute_format.find("N")
-            size = handle_dynamic_batch_size(size, batch_idx)
 
           conv_rs = tf.slice(conv_rs, begin=begin, size=size)
 
@@ -209,19 +198,13 @@ class ConvMixin(BroadcastMixin):
             ]
           conv_output_shape.insert(compute_c_idx, weights_shape[-2])
 
-          # process dynamic batch size
-          if conv_output_shape[storage_format.find("N")] is None:
-            batch_idx = storage_format.find("N")
-            conv_output_shape = handle_dynamic_batch_size(conv_output_shape,
-                    batch_idx)
-
           # make strides to match input rank
           strides_full = [1] + strides
           strides_full.insert(compute_c_idx, 1)
 
           # get corresponding function in tf
           if spatial_size == 1:
-            conv_func = tf.contrib.nn.conv1d_transpose
+            conv_func = tf.nn.conv1d_transpose
             strides_full = strides[0]
           elif spatial_size == 2:
             conv_func = tf.nn.conv2d_transpose

--- a/test/backend/test_dynamic_shape.py
+++ b/test/backend/test_dynamic_shape.py
@@ -33,8 +33,8 @@ class TestDynamicShape(unittest.TestCase):
   def test_arg_max(self):
     if legacy_opset_pre_ver(12):
       raise unittest.SkipTest(
-          "ONNX version {} doesn't support select_last_index attribute for ArgMax that depends on shape.".format(
-              defs.onnx_opset_version()))
+          "ONNX version {} doesn't support select_last_index attribute for ArgMax that depends on shape."
+          .format(defs.onnx_opset_version()))
     axis = 1
     node_def = helper.make_node("ArgMax",
                                 inputs=['X'],
@@ -51,7 +51,8 @@ class TestDynamicShape(unittest.TestCase):
         outputs=[
             helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
         ])
-    x = np.array([[ 1, 2, 3, 5, 3, 4, 5, 1 ], [ 2, 9, 3, 5, 9, 4, 5, 1 ]]).astype(np.float32)
+    x = np.array([[1, 2, 3, 5, 3, 4, 5, 1], [2, 9, 3, 5, 9, 4, 5,
+                                             1]]).astype(np.float32)
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
     output = tf_rep.run({"X": x})
     expected_output = np.argmax(np.flip(x, axis), axis=axis)
@@ -61,8 +62,8 @@ class TestDynamicShape(unittest.TestCase):
   def test_arg_min(self):
     if legacy_opset_pre_ver(12):
       raise unittest.SkipTest(
-          "ONNX version {} doesn't support select_last_index attribute for ArgMin that depends on shape.".format(
-              defs.onnx_opset_version()))
+          "ONNX version {} doesn't support select_last_index attribute for ArgMin that depends on shape."
+          .format(defs.onnx_opset_version()))
     axis = 1
     node_def = helper.make_node("ArgMin",
                                 inputs=['X'],
@@ -79,7 +80,8 @@ class TestDynamicShape(unittest.TestCase):
         outputs=[
             helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None, None])
         ])
-    x = np.array([[ 1, 2, 3, 5, 3, 4, 5, 1 ], [ 2, 7, 3, 5, 2, 4, 5, 6 ]]).astype(np.float32)
+    x = np.array([[1, 2, 3, 5, 3, 4, 5, 1], [2, 7, 3, 5, 2, 4, 5,
+                                             6]]).astype(np.float32)
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
     output = tf_rep.run({"X": x})
     expected_output = np.argmin(np.flip(x, axis), axis=axis)
@@ -103,14 +105,16 @@ class TestDynamicShape(unittest.TestCase):
         [node_def],
         name="test_unknown_shape",
         inputs=[
-            helper.make_tensor_value_info("X", TensorProto.FLOAT, [None, None, None, None]),
+            helper.make_tensor_value_info("X", TensorProto.FLOAT,
+                                          [None, None, None, None]),
             helper.make_tensor_value_info("scale", TensorProto.FLOAT, [None]),
             helper.make_tensor_value_info("bias", TensorProto.FLOAT, [None]),
             helper.make_tensor_value_info("mean", TensorProto.FLOAT, [None]),
             helper.make_tensor_value_info("var", TensorProto.FLOAT, [None])
         ],
         outputs=[
-            helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None, None, None, None])
+            helper.make_tensor_value_info("Y", TensorProto.FLOAT,
+                                          [None, None, None, None])
         ])
     x_shape = [3, 5, 4, 2]
     param_shape = [5]
@@ -126,7 +130,13 @@ class TestDynamicShape(unittest.TestCase):
     _bias = bias.reshape(_param_shape)
     golden = self._batch_normalization(x, _m, _v, _bias, _scale, 0.001)
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x, "scale": scale, "bias": bias, "mean": m, "var": v})
+    output = tf_rep.run({
+        "X": x,
+        "scale": scale,
+        "bias": bias,
+        "mean": m,
+        "var": v
+    })
     np.testing.assert_almost_equal(output["Y"], golden, decimal=5)
 
   def test_compress(self):
@@ -171,11 +181,14 @@ class TestDynamicShape(unittest.TestCase):
         [node_def],
         name="test_unknown_shape",
         inputs=[
-            helper.make_tensor_value_info("X", TensorProto.FLOAT, [None, 3, 4, 6]),
-            helper.make_tensor_value_info("weights", TensorProto.FLOAT, weight_shape)
+            helper.make_tensor_value_info("X", TensorProto.FLOAT,
+                                          [None, None, None, None]),
+            helper.make_tensor_value_info("weights", TensorProto.FLOAT,
+                                          [None, None, None, None])
         ],
         outputs=[
-            helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None, None, None, None])
+            helper.make_tensor_value_info("Y", TensorProto.FLOAT,
+                                          [None, None, None, None])
         ])
 
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
@@ -559,20 +572,19 @@ class TestDynamicShape(unittest.TestCase):
     kernel_shape = [2, 2]
     strides = [2, 2]
 
-    maxpool_node_def = helper.make_node(
-            op_type="MaxPool",
-            inputs=["X"],
-            outputs=["Pool", "Indices"],
-            kernel_shape=kernel_shape,
-            strides=strides)
+    maxpool_node_def = helper.make_node(op_type="MaxPool",
+                                        inputs=["X"],
+                                        outputs=["Pool", "Indices"],
+                                        kernel_shape=kernel_shape,
+                                        strides=strides)
 
-    maxunpool_node_def = helper.make_node(
-        "MaxUnpool", ["Pool", "Indices"], ["Y"],
-        kernel_shape=kernel_shape,
-        strides=strides)
+    maxunpool_node_def = helper.make_node("MaxUnpool", ["Pool", "Indices"],
+                                          ["Y"],
+                                          kernel_shape=kernel_shape,
+                                          strides=strides)
 
     graph_def = helper.make_graph(
-        [maxpool_node_def,maxunpool_node_def],
+        [maxpool_node_def, maxunpool_node_def],
         name="test_unknown_shape",
         inputs=[
             helper.make_tensor_value_info("X", TensorProto.FLOAT,
@@ -591,8 +603,8 @@ class TestDynamicShape(unittest.TestCase):
         for i3 in range(0, input_shape[2], 2):
           for i4 in range(0, input_shape[3], 2):
             max_val = float('-inf')
-            for j1 in range(i3,i3+2):
-              for j2 in range(i4,i4+2):
+            for j1 in range(i3, i3 + 2):
+              for j2 in range(i4, i4 + 2):
                 if x[i1][i2][j1][j2] > max_val:
                   max_val = x[i1][i2][j1][j2]
                   max_ind = (j1, j2)


### PR DESCRIPTION
1. Add dynamic shape support for input x and w in conv_mixin.py
2. Fix issue #750
3. Update CLI.md
4. Update common.tf_helper to include dtype(int32/int64) as input

Signed-off-by: Winnie Tsang <wtsang@us.ibm.com>
