### PR TITLE
Add data cast support for Clip and Mod

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -33,7 +33,7 @@ Notes:
 |Cast|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**9**:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|**13**:small_orange_diamond:|Cast|
 |Ceil|**1**|1|1|1|1|**6**|6|6|6|6|6|6|**13**|Ceil|
 |Celu|-|-|-|-|-|-|-|-|-|-|-|**12**|12|Celu|
-|Clip|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**11**:small_orange_diamond:|**12**:small_orange_diamond:|**13**:small_orange_diamond:|Clip|
+|Clip|**1**|1|1|1|1|**6**|6|6|6|6|**11**|**12**|**13**|Clip|
 |Compress|-|-|-|-|-|-|-|-|**9**|9|**11**|11|11|Compress|
 |Concat|**1**|1|1|**4**|4|4|4|4|4|4|**11**|11|**13**:small_red_triangle:|Concat|
 |ConcatFromSequence|-|-|-|-|-|-|-|-|-|-|**11**:small_orange_diamond:|11:small_orange_diamond:|11:small_orange_diamond:|ConcatFromSequence|
@@ -96,7 +96,7 @@ Notes:
 |Mean|**1**|1|1|1|1|**6**|6|**8**|8|8|8|8|**13**:small_red_triangle:|Mean|
 |MeanVarianceNormalization|-|-|-|-|-|-|-|-|**9**|9|9|9|**13**:small_red_triangle:|MeanVarianceNormalization|
 |Min|**1**|1|1|1|1|**6**|6|**8**|8|8|8|**12**|**13**|Min|
-|Mod|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|**13**:small_red_triangle:|Mod|
+|Mod|-|-|-|-|-|-|-|-|-|**10**|10|10|**13**|Mod|
 |Mul|**1**|1|1|1|1|**6**|**7**|7|7|7|7|7|**13**:small_red_triangle:|Mul|
 |Multinomial|-|-|-|-|-|-|**7**:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|Multinomial|
 |Neg|**1**|1|1|1|1|**6**|6|6|6|6|6|6|**13**:small_red_triangle:|Neg|
@@ -183,15 +183,13 @@ ONNX-TF Supported Operators / ONNX Operators: 95 / 162
 
 Notes:
 1. Cast: Cast string to data types other than float32/float64/int32/int64 is not supported in Tensorflow
-2. Clip: Clip input in uint64 is not supported in Tensorflow.
-3. ConcatFromSequence: new_axis=1 not supported in Tensorflow.
-4. ConvTranspose: ConvTranspose with dilations != 1, or transposed convolution for 4D or higher are not supported in Tensorflow.
-5. GRU: GRU with clip or GRU with linear_before_reset, or GRU not using sigmoid for z and r, or GRU using Elu as the activation function with alpha != 1, or GRU using HardSigmoid as the activation function with alpha != 0.2 or beta != 0.5 are not supported in TensorFlow.
-6. LSTM: LSTM not using sigmoid for `f`, or LSTM not using the same activation for `g` and `h` are not supported in Tensorflow.
-7. MaxPool: MaxPoolWithArgmax with pad is None or incompatible mode, or MaxPoolWithArgmax with 4D or higher input, or MaxPoolWithArgmax with column major are not supported in Tensorflow.
-8. Mod: Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 are not supported in Tensorflow.
-9. RNN: RNN with clip is not supported in Tensorflow.
-10. Resize: Resize required 4D input in Tensorflow. For opset 11, only the following attributes and inputs conbination are supported in Tensorflow:
+2. ConcatFromSequence: new_axis=1 not supported in Tensorflow.
+3. ConvTranspose: ConvTranspose with dilations != 1, or transposed convolution for 4D or higher are not supported in Tensorflow.
+4. GRU: GRU with clip or GRU with linear_before_reset, or GRU not using sigmoid for z and r, or GRU using Elu as the activation function with alpha != 1, or GRU using HardSigmoid as the activation function with alpha != 0.2 or beta != 0.5 are not supported in TensorFlow.
+5. LSTM: LSTM not using sigmoid for `f`, or LSTM not using the same activation for `g` and `h` are not supported in Tensorflow.
+6. MaxPool: MaxPoolWithArgmax with pad is None or incompatible mode, or MaxPoolWithArgmax with 4D or higher input, or MaxPoolWithArgmax with column major are not supported in Tensorflow.
+7. RNN: RNN with clip is not supported in Tensorflow.
+8. Resize: Resize required 4D input in Tensorflow. For opset 11, only the following attributes and inputs conbination are supported in Tensorflow:
 	1. mode=nearest, coordinate_transformation_mode=align_corners, nearest_mode=round_prefer_ceil, can use scales(*) or sizes.
 	2. mode=nearest, coordinate_transformation_mode=asymmetric, nearest_mode=floor, can use scales(*) or sizes.
 	3. mode=nearest, coordinate_transformation_mode=tf_half_pixel_for_nn, nearest_mode=floor, can use scales(*) or sizes.
@@ -204,5 +202,5 @@ Notes:
 	10. mode=nearest, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, nearest_mode=round_prefer_ceil, can use scales or sizes.
 	11. mode=linear, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, can use scales or sizes.
 	- Note (*): The accuracy of your model will go down, if the height and the width of the new sizes(scales * origial sizes) are not in whole numbers.
-11. SplitToSequence: Scalar as the split input not supported.
-12. Upsample: Upsample required 4D input in Tensorflow.
+9. SplitToSequence: Scalar as the split input not supported.
+10. Upsample: Upsample required 4D input in Tensorflow.

--- a/onnx_tf/handlers/backend/clip.py
+++ b/onnx_tf/handlers/backend/clip.py
@@ -1,26 +1,37 @@
 import tensorflow as tf
 
 from onnx_tf.common import exception
+from onnx_tf.common import sys_config
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
-from onnx_tf.handlers.handler import partial_support
-from onnx_tf.handlers.handler import ps_description
+import onnx_tf.common.data_type as data_type
 
 
 @onnx_op("Clip")
-@partial_support(True)
-@ps_description("Clip input in uint64 is not supported in Tensorflow.")
 class Clip(BackendHandler):
+  cast_map = {
+      tf.uint8: tf.int32,
+      tf.uint16: tf.int32,
+      tf.uint32: tf.int64,
+      tf.int8: tf.int32,
+      tf.int16: tf.int32
+  }
+  cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+  supported_types = [
+      tf.int32, tf.int64, tf.float16, tf.float32, tf.float64, tf.bfloat16
+  ]
 
   @classmethod
   def args_check(cls, node, **kwargs):
     x = kwargs["tensor_dict"][node.inputs[0]]
-    # uint64 cannot upcast to any tensorflow supported datatype
-    # for tf.clip_by_value that didn't lose precision
-    if x.dtype == tf.uint64:
-      exception.OP_UNSUPPORTED_EXCEPT(
-          "Clip input, min and max in " + str(x.dtype) + " datatype",
-          "Tensorflow")
+
+    # throw an error if the data type is not natively supported by
+    # Tensorflow, cannot be safely cast, and auto-cast option is False
+    if x.dtype in cls.cast_map and cls.cast_map[x.dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "Clip input " + node.inputs[0] + " with data type '" +
+          data_type.tf_to_np_str(x.dtype) + "'",
+          data_type.tf_to_np_str_list(cls.supported_types))
 
   @classmethod
   def _common(cls, node, **kwargs):
@@ -41,15 +52,14 @@ class Clip(BackendHandler):
 
     # tf.clip_by_value doesn't support uint8, uint16, uint32, int8 and int16
     # dtype for x, therefore need to upcast it to tf.int32 or tf.int64
-    if x_dtype in [tf.uint8, tf.uint16, tf.uint32, tf.int8, tf.int16]:
-      cast_to = tf.int64 if x_dtype == tf.uint32 else tf.int32
-      x = tf.cast(x, cast_to)
-      clip_value_min = tf.cast(clip_value_min, cast_to)
-      clip_value_max = tf.cast(clip_value_max, cast_to)
-      y = tf.clip_by_value(x, clip_value_min, clip_value_max)
-      y = tf.cast(y, x_dtype)
-    else:
-      y = tf.clip_by_value(x, clip_value_min, clip_value_max)
+    need_cast = x_dtype in cls.cast_map
+    x = tf.cast(x, cls.cast_map[x_dtype]) if need_cast else x
+    clip_value_min = tf.cast(
+        clip_value_min, cls.cast_map[x_dtype]) if need_cast else clip_value_min
+    clip_value_max = tf.cast(
+        clip_value_max, cls.cast_map[x_dtype]) if need_cast else clip_value_max
+    y = tf.clip_by_value(x, clip_value_min, clip_value_max)
+    y = tf.cast(y, x_dtype) if need_cast else y
 
     return [y]
 

--- a/onnx_tf/handlers/backend/mod.py
+++ b/onnx_tf/handlers/backend/mod.py
@@ -1,38 +1,71 @@
 import tensorflow as tf
 
 from onnx_tf.common import exception
+from onnx_tf.common import sys_config
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
-from onnx_tf.handlers.handler import partial_support
-from onnx_tf.handlers.handler import ps_description
 from .math_mixin import ArithmeticMixin
+import onnx_tf.common.data_type as data_type
 
 
 @onnx_op("Mod")
-@partial_support(True)
-@ps_description(
-    "Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 " +
-    "are not supported in Tensorflow.")
 class Mod(ArithmeticMixin, BackendHandler):
+  cast_map = {
+      tf.uint8: tf.int32,
+      tf.uint16: tf.int32,
+      tf.uint32: tf.int64,
+      tf.int8: tf.int32,
+      tf.int16: tf.int32
+  }
+  cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+  supported_types = [
+      tf.int32, tf.int64, tf.float16, tf.float32, tf.float64, tf.bfloat16
+  ]
 
   @classmethod
   def args_check(cls, node, **kwargs):
-    unsupported_dtype = [
-        tf.int8, tf.int16, tf.uint8, tf.uint16, tf.uint32, tf.uint64
-    ]
     x = kwargs["tensor_dict"][node.inputs[0]]
     y = kwargs["tensor_dict"][node.inputs[1]]
-    if x.dtype in unsupported_dtype:
-      exception.OP_UNSUPPORTED_EXCEPT("Mod Dividend in " + str(x.dtype),
-                                      "Tensorflow")
-    if y.dtype in unsupported_dtype:
-      exception.OP_UNSUPPORTED_EXCEPT("Mod Divisor in " + str(y.dtype),
+
+    # throw an error if the data type is not natively supported by
+    # Tensorflow, cannot be safely cast, and auto-cast option is False
+    if x.dtype in cls.cast_map and cls.cast_map[x.dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "Mod input " + node.inputs[0] + " with data type '" +
+          data_type.tf_to_np_str(x.dtype) + "'",
+          data_type.tf_to_np_str_list(cls.supported_types))
+
+    # throw an error if inputs A and B are not in the same data type
+    if x.dtype != y.dtype:
+      exception.OP_UNSUPPORTED_EXCEPT("Mod with inputs in different data types",
                                       "Tensorflow")
 
   @classmethod
-  def version_10(cls, node, **kwargs):
+  def _common(cls, node, **kwargs):
+    x = kwargs["tensor_dict"][node.inputs[0]]
+    y = kwargs["tensor_dict"][node.inputs[1]]
+    x_dtype = x.dtype
+    y_dtype = y.dtype
     fmod = node.attrs.get("fmod", 0)
-    tf_func = tf.math.floormod
-    if fmod == 1:
-      tf_func = tf.truncatemod
-    return [cls.make_tensor_from_onnx_node(node, tf_func=tf_func, **kwargs)]
+
+    # cast inputs if not natively support by Tensorflow API
+    need_cast = x_dtype in cls.cast_map
+    x = tf.cast(x, cls.cast_map[x_dtype]) if need_cast else x
+    y = tf.cast(y, cls.cast_map[y_dtype]) if need_cast else y
+
+    tf_func = tf.truncatemod if fmod == 1 else tf.math.floormod
+    z = cls.make_tensor_from_onnx_node(node,
+                                       tf_func=tf_func,
+                                       inputs=[x, y],
+                                       **kwargs)
+    z = tf.cast(z, x_dtype) if need_cast else z
+
+    return [z]
+
+  @classmethod
+  def version_10(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
+    return cls._common(node, **kwargs)

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -94,7 +94,7 @@ backend_opset_version = {
     'Mean': [1, 6, 8],
     'MeanVarianceNormalization': [1, 9],
     'Min': [1, 6, 8, 12, 13],
-    'Mod': [10],
+    'Mod': [10, 13],
     'Momentum': [],
     'Mul': [1, 6, 7],
     'Multinomial': [],
@@ -190,7 +190,6 @@ backend_opset_version = {
 backend_partial_support = {
     'Cast': 'Cast string to data types other than float32/float64/int32/int64 '
             'is not supported in Tensorflow',
-    'Clip': 'Clip input in uint64 is not supported in Tensorflow.',
     'ConcatFromSequence': 'new_axis=1 not supported in Tensorflow.',
     'ConvTranspose': 'ConvTranspose with dilations != 1, or transposed '
                      'convolution for 4D or higher are not supported in '
@@ -206,8 +205,6 @@ backend_partial_support = {
                'MaxPoolWithArgmax with 4D or higher input, or '
                'MaxPoolWithArgmax with column major are not supported in '
                'Tensorflow.',
-    'Mod': 'Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 '
-           'are not supported in Tensorflow.',
     'RNN': 'RNN with clip is not supported in Tensorflow.',
     'Resize': 'Resize required 4D input in Tensorflow. For opset 11, only the '
               'following attributes and inputs conbination are supported in '

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -2286,6 +2286,12 @@ class TestNode(unittest.TestCase):
     node_def = helper.make_node("Mod", ["X", "Y"], ["Z"], fmod=1)
     output = run_node(node_def, [x, y])
     np.testing.assert_almost_equal(output["Z"], np.fmod(x, y))
+    # test data cast for int16
+    x = self._get_rnd_int(shape=[5, 5], low=1, high=100, dtype=np.int16)
+    y = self._get_rnd_int(shape=[5, 5], low=1, high=100, dtype=np.int16)
+    node_def = helper.make_node("Mod", ["X", "Y"], ["Z"], fmod=0)
+    output = run_node(node_def, [x, y])
+    np.testing.assert_almost_equal(output["Z"], np.mod(x, y))
 
   def test_neg(self):
     node_def = helper.make_node("Neg", ["X"], ["Y"])


### PR DESCRIPTION
Add data cast support for Clip and Mod so that all ONNX data
types are supported for these two operators now.

Also add a test case in test_node.py for mod to verify data
cast working.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>