### PR TITLE
Fix dynamic shape test and move handler's variable creation into BackendTFModule.__init__

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -22,7 +22,7 @@ optional arguments:
 ### Convert:
 
 #### From ONNX to Tensorflow:
-`onnx-tf convert -i /path/to/input.onnx -o /path/to/output.pb`
+`onnx-tf convert -i /path/to/input.onnx -o /path/to/output`
 
 More information: `onnx-tf convert -h`
 ```

--- a/doc/CLI_template.md
+++ b/doc/CLI_template.md
@@ -14,7 +14,7 @@ More information: `onnx-tf -h`
 ### Convert:
 
 #### From ONNX to Tensorflow:
-`onnx-tf convert -i /path/to/input.onnx -o /path/to/output.pb`
+`onnx-tf convert -i /path/to/input.onnx -o /path/to/output`
 
 More information: `onnx-tf convert -h`
 ```

--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -160,7 +160,38 @@ class TensorflowBackend(Backend):
     tf_rep.signatures = signatures
     tf_rep.tensor_dict = module.gen_tensor_dict(
         input_dict) if gen_tensor_dict else None
+    tf_rep.onnx_op_list = cls._get_onnx_op_list(graph_def)
     return tf_rep
+
+  @classmethod
+  def _get_onnx_op_list(cls, graph_def):
+    """ Get ONNX operator counts of the model.
+
+    :param graph_def: ONNX GraphProto object.
+    :return: Dictionary of all operators counts in the model.
+    """
+
+    def get_onnx_op_from_graph_and_subgraph(graph, op_list):
+      for node in graph.node:
+        op_list[node.op_type] = 1 if node.op_type not in op_list.keys(
+        ) else op_list[node.op_type] + 1
+        if node.op_type in ['Loop', 'Scan']:
+          onnx_node = OnnxNode(node)
+          body = onnx_node.attrs["body"]
+          op_list = get_onnx_op_from_graph_and_subgraph(body, op_list)
+        elif node.op_type == 'If':
+          onnx_node = OnnxNode(node)
+          then_branch = onnx_node.attrs['then_branch']
+          op_list = get_onnx_op_from_graph_and_subgraph(then_branch, op_list)
+          else_branch = onnx_node.attrs['else_branch']
+          op_list = get_onnx_op_from_graph_and_subgraph(else_branch, op_list)
+      return op_list
+
+    op_list = get_onnx_op_from_graph_and_subgraph(graph_def, dict())
+    sorted_op_list = dict()
+    for key in sorted(op_list):
+      sorted_op_list[key] = op_list[key]
+    return sorted_op_list
 
   @classmethod
   def run_node(cls, node, inputs, device='CPU', outputs_info=None, **kwargs):

--- a/onnx_tf/backend_rep.py
+++ b/onnx_tf/backend_rep.py
@@ -51,6 +51,14 @@ class TensorflowRep(BackendRep):
     self._tensor_dict = tensor_dict
 
   @property
+  def onnx_op_list(self):
+    return self._onnx_op_list
+
+  @onnx_op_list.setter
+  def onnx_op_list(self, onnx_op_list):
+    self._onnx_op_list = onnx_op_list
+
+  @property
   def tf_module(self):
     return self._tf_module
 
@@ -80,11 +88,13 @@ class TensorflowRep(BackendRep):
       # single input
       feed_dict = dict([(self.inputs[0], inputs)])
 
-    input_dict = dict(
-        [(x[0], tf.constant(x[1])) for x in feed_dict.items()])
+    input_dict = dict([(x[0], tf.constant(x[1])) for x in feed_dict.items()])
 
     output_values = self.tf_module(**input_dict)
-    output_values = [val.numpy() if isinstance(val, tf.Tensor) else val for val in output_values]
+    output_values = [
+        val.numpy() if isinstance(val, tf.Tensor) else val
+        for val in output_values
+    ]
 
     return namedtupledict('Outputs', self.outputs)(*output_values)
 
@@ -99,4 +109,8 @@ class TensorflowRep(BackendRep):
 
     :returns: none.
     """
-    tf.saved_model.save(self.tf_module, path, signatures=self.tf_module.__call__.get_concrete_function(**self.signatures))
+    tf.saved_model.save(
+        self.tf_module,
+        path,
+        signatures=self.tf_module.__call__.get_concrete_function(
+            **self.signatures))

--- a/onnx_tf/backend_tf_module.py
+++ b/onnx_tf/backend_tf_module.py
@@ -1,3 +1,4 @@
+from onnx.defs import ONNX_DOMAIN
 import tensorflow as tf
 from onnx_tf.pb_wrapper import OnnxNode
 
@@ -13,6 +14,8 @@ class BackendTFModule(tf.Module):
     self.backend = backend
     self.outputs = []
     self.initializer_dict = self._get_initializer_from_graph_and_subgraphs(
+        self.graph_def, dict())
+    self.handler_variables = self._create_handlers_variables(
         self.graph_def, dict())
 
   # get initializer from the main graph and all subgraphs in loop or if or scan
@@ -37,10 +40,40 @@ class BackendTFModule(tf.Module):
             else_branch, graph_tensor_dict)
     return graph_tensor_dict
 
+  # create tf.Variable for handlers that required to use variable in handler
+  def _create_handlers_variables(self, graph, vars_dict):
+    handlers = self.backend._get_handlers(self.opset)
+    for node in graph.node:
+      handler = handlers[node.domain].get(
+          node.op_type, None) if node.domain in handlers else None
+      if handler and bool(handler.get_req_vars_template()):
+        for v_name, v_template in handler.get_req_vars_template().items():
+          v_init, v_shape = v_template
+          v_count = 0
+          for var_name in vars_dict.keys():
+            v_count = v_count + 1 if var_name.startswith(v_name) else v_count
+          v_name = v_name + '_' + str(v_count)
+          vars_dict[v_name] = tf.Variable(v_init,
+                                          dtype=v_init.dtype,
+                                          shape=v_shape,
+                                          name=v_name)
+      if node.op_type in ['Loop', 'Scan']:
+        onnx_node = OnnxNode(node)
+        body = onnx_node.attrs["body"]
+        vars_dict = self._create_handlers_variables(body, vars_dict)
+      elif node.op_type == 'If':
+        onnx_node = OnnxNode(node)
+        then_branch = onnx_node.attrs['then_branch']
+        vars_dict = self._create_handlers_variables(then_branch, vars_dict)
+        else_branch = onnx_node.attrs['else_branch']
+        vars_dict = self._create_handlers_variables(else_branch, vars_dict)
+    return vars_dict
+
   @tf.function
   def gen_tensor_dict(self, input_dict):
     tensor_dict = dict(input_dict)
     tensor_dict.update(self.initializer_dict)
+    tensor_dict.update(self.handler_variables)
 
     for node in self.graph_def.node:
       onnx_node = OnnxNode(node)
@@ -52,12 +85,18 @@ class BackendTFModule(tf.Module):
       curr_node_output_map = dict(zip(onnx_node.outputs, output_ops))
       tensor_dict.update(curr_node_output_map)
 
+    # reset VAR_COUNT in handlers(currently all handlers are in ONNX_DOMAIN)
+    # TODO update this when we support handlers in other domain
+    for _, handler in self.handlers[ONNX_DOMAIN].items():
+      handler.VAR_COUNT = 0
+
     return tensor_dict
 
   @tf.function
   def __call__(self, **kwargs):
     tensor_dict = kwargs
     tensor_dict.update(self.initializer_dict)
+    tensor_dict.update(self.handler_variables)
 
     for node in self.graph_def.node:
       onnx_node = OnnxNode(node)
@@ -70,4 +109,9 @@ class BackendTFModule(tf.Module):
       tensor_dict.update(curr_node_output_map)
 
     outputs = [tensor_dict[output] for output in self.outputs]
+
+    # reset VAR_COUNT in handlers(currently all handlers are in ONNX_DOMAIN)
+    # TODO update this when we support handlers in other domain
+    for _, handler in self.handlers[ONNX_DOMAIN].items():
+      handler.VAR_COUNT = 0
     return outputs

--- a/onnx_tf/handlers/backend/conv_mixin.py
+++ b/onnx_tf/handlers/backend/conv_mixin.py
@@ -46,14 +46,15 @@ class ConvMixin(BroadcastMixin):
 
     if "kernel_shape" in node.attrs.keys():
       kernel_shape = node.attrs["kernel_shape"]
-      assert in_weights.get_shape().as_list()[2:] == kernel_shape, (
-          "kernel_shape "
-          "attr of convolution does not match the actual weight "
-          "passed to this operation, attr {}, actual {}").format(
-              kernel_shape,
-              in_weights.get_shape().as_list())
+      if in_weights.get_shape().is_fully_defined():
+        assert in_weights.get_shape().as_list()[2:] == kernel_shape, (
+            "kernel_shape "
+            "attr of convolution does not match the actual weight "
+            "passed to this operation, attr {}, actual {}").format(
+                kernel_shape,
+                in_weights.get_shape().as_list())
     else:
-      kernel_shape = in_weights.get_shape().as_list()[2:]
+      kernel_shape = tf_shape(in_weights, tf.int32)[2:]
 
     weights = tf.transpose(in_weights, perm)
     dilations = node.attrs.get("dilations", [1] * spatial_size)

--- a/onnx_tf/handlers/backend/dilated_pooling.py
+++ b/onnx_tf/handlers/backend/dilated_pooling.py
@@ -601,9 +601,12 @@ class DilatedPooling(object):
 
       # if there was padding, recalculate the returned index
       # to exclude the padding
-      count_nonzero_op = np.count_nonzero if self.is_known_shape else tf.math.count_nonzero
-      if count_nonzero_op(self.pads) != 0:
-        new_ind = self._calc_argmax_without_padding(new_ind)
+      if self.is_known_shape:
+        if np.count_nonzero(self.pads) != 0:
+          new_ind = self._calc_argmax_without_padding(new_ind)
+      else:
+        new_ind = tf.where(tf.not_equal(tf.math.count_nonzero(self.pads), 0),
+                           self._calc_argmax_without_padding(new_ind), new_ind)
 
     return (pooled, new_ind)
 

--- a/onnx_tf/handlers/backend/random_normal_like.py
+++ b/onnx_tf/handlers/backend/random_normal_like.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 
+from onnx_tf.common.tf_helper import tf_shape
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
@@ -15,5 +16,5 @@ class RandomNormalLike(BackendHandler):
 
   @classmethod
   def version_1(cls, node, **kwargs):
-    inputs = [kwargs["tensor_dict"][node.inputs[0]].get_shape()]
+    inputs = [tf_shape(kwargs["tensor_dict"][node.inputs[0]])]
     return [cls.make_tensor_from_onnx_node(node, inputs=inputs, **kwargs)]

--- a/onnx_tf/handlers/backend_handler.py
+++ b/onnx_tf/handlers/backend_handler.py
@@ -24,6 +24,15 @@ class BackendHandler(Handler):
   """
 
   TF_FUNC = None
+  VAR_COUNT = 0
+
+  @classmethod
+  def get_req_vars_template(cls):
+    """ Get required variables template.
+
+    :return: Dict.
+    """
+    return {}
 
   @classmethod
   def get_attrs_processor_param(cls):
@@ -183,8 +192,8 @@ class BackendHandler(Handler):
 
     attrs = {p: v for p, v in attrs.items() if p in params}
     kwargs = dict(zip(params, inputs))
-    ambiguous_arguments = any(kwargs.get(p) is not None and v is not None
-                              for p, v in attrs.items())
+    ambiguous_arguments = any(
+        kwargs.get(p) is not None and v is not None for p, v in attrs.items())
     if ambiguous_arguments:
       raise TypeError('Ambiguous arguments for {}()'.format(tf_func.__name__))
     kwargs.update((p, v) for p, v in attrs.items() if v is not None)

--- a/test/backend/test_dynamic_shape.py
+++ b/test/backend/test_dynamic_shape.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import unittest
+import shutil
 
 from onnx import defs
 from onnx import helper
@@ -53,11 +54,18 @@ class TestDynamicShape(unittest.TestCase):
         ])
     x = np.array([[1, 2, 3, 5, 3, 4, 5, 1], [2, 9, 3, 5, 9, 4, 5,
                                              1]]).astype(np.float32)
+    # get tf_rep
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x})
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/arg_max'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x)
     expected_output = np.argmax(np.flip(x, axis), axis=axis)
     expected_output = x.shape[axis] - expected_output - 1
-    np.testing.assert_almost_equal(output['Y'], expected_output)
+    np.testing.assert_almost_equal(tf_model_output[0], expected_output)
 
   def test_arg_min(self):
     if legacy_opset_pre_ver(12):
@@ -83,10 +91,16 @@ class TestDynamicShape(unittest.TestCase):
     x = np.array([[1, 2, 3, 5, 3, 4, 5, 1], [2, 7, 3, 5, 2, 4, 5,
                                              6]]).astype(np.float32)
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x})
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/arg_min'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x)
     expected_output = np.argmin(np.flip(x, axis), axis=axis)
     expected_output = x.shape[axis] - expected_output - 1
-    np.testing.assert_almost_equal(output['Y'], expected_output)
+    np.testing.assert_almost_equal(tf_model_output[0], expected_output)
 
   def _batch_normalization(self, x, mean, variance, bias, scale,
                            variance_epsilon):
@@ -130,14 +144,14 @@ class TestDynamicShape(unittest.TestCase):
     _bias = bias.reshape(_param_shape)
     golden = self._batch_normalization(x, _m, _v, _bias, _scale, 0.001)
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({
-        "X": x,
-        "scale": scale,
-        "bias": bias,
-        "mean": m,
-        "var": v
-    })
-    np.testing.assert_almost_equal(output["Y"], golden, decimal=5)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/batch_normalization'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x, scale=scale, bias=bias, mean=m, var=v)
+    np.testing.assert_almost_equal(tf_model_output[0], golden, decimal=5)
 
   def test_compress(self):
     if legacy_opset_pre_ver(9):
@@ -164,8 +178,15 @@ class TestDynamicShape(unittest.TestCase):
     x = self._get_rnd_float32(shape=[5, 5, 5])
     cond = np.array([1, 0, 1]).astype(np.bool)
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x, "condition": cond})
-    np.testing.assert_almost_equal(output['Y'], np.compress(cond, x, axis=axis))
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/compress'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x, condition=cond)
+    np.testing.assert_almost_equal(tf_model_output[0],
+                                   np.compress(cond, x, axis=axis))
 
   def test_conv_transpose(self):
     # test dynamic batch size on transpose of 2d convolution
@@ -192,7 +213,13 @@ class TestDynamicShape(unittest.TestCase):
         ])
 
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x, "weights": weights})
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/conv_transpose'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x, weights=weights)
 
     padh_left = weight_shape[2] - 1 - pads[0]
     padh_right = weight_shape[2] - 1 - pads[1]
@@ -219,7 +246,7 @@ class TestDynamicShape(unittest.TestCase):
                         k2 - padw_left] * weights[c][m][kh + h - 1 -
                                                         k1][kw + w - 1 - k2]
 
-    np.testing.assert_almost_equal(output["Y"], test_output, decimal=5)
+    np.testing.assert_almost_equal(tf_model_output[0], test_output, decimal=5)
 
   def test_eye_like(self):
     if legacy_opset_pre_ver(9):
@@ -242,8 +269,14 @@ class TestDynamicShape(unittest.TestCase):
             helper.make_tensor_value_info("y", TensorProto.FLOAT, [None, None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"x": x})
-    np.testing.assert_equal(output["y"], y)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/eye_like'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(x=x)
+    np.testing.assert_equal(tf_model_output[0], y)
 
   def test_flatten(self):
     shape = [2, 3, 4]
@@ -259,9 +292,15 @@ class TestDynamicShape(unittest.TestCase):
         ],
         outputs=[helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None])])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x})
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/flatten'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x)
     new_shape = (np.prod(shape[0:axis]).astype(int), -1)
-    np.testing.assert_almost_equal(output["Y"], np.reshape(x, new_shape))
+    np.testing.assert_almost_equal(tf_model_output[0], np.reshape(x, new_shape))
 
   def test_gather_nd(self):
     if legacy_opset_pre_ver(11):
@@ -286,8 +325,14 @@ class TestDynamicShape(unittest.TestCase):
             helper.make_tensor_value_info("outputs", TensorProto.INT32, [None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"data": data, "indices": indices})
-    np.testing.assert_almost_equal(output["outputs"], ref_output)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/gather_nd'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(data=data, indices=indices)
+    np.testing.assert_almost_equal(tf_model_output[0], ref_output)
 
   def test_is_inf(self):
     if legacy_opset_pre_ver(10):
@@ -305,8 +350,14 @@ class TestDynamicShape(unittest.TestCase):
         ],
         outputs=[helper.make_tensor_value_info("Y", TensorProto.BOOL, [None])])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": inp})
-    np.testing.assert_equal(output["Y"], expected_output)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/is_inf'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=inp)
+    np.testing.assert_equal(tf_model_output[0], expected_output)
 
   def test_matmul_integer(self):
     if legacy_opset_pre_ver(10):
@@ -343,13 +394,17 @@ class TestDynamicShape(unittest.TestCase):
                                           [None, None, None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({
-        "A": A,
-        "B": B,
-        "a_zero_point": a_zero_point,
-        "b_zero_point": b_zero_point
-    })
-    np.testing.assert_almost_equal(output["Z"], z)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/matmul_integer'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(A=A,
+                               B=B,
+                               a_zero_point=a_zero_point,
+                               b_zero_point=b_zero_point)
+    np.testing.assert_almost_equal(tf_model_output[0], z)
     # A & B are 4-D tensor and a_zero_point & b_zero_point are 1-D tensor
     A = self._get_rnd_int(-20, 20, shape=(2, 5, 3, 4), dtype=np.int8)
     B = self._get_rnd_int(-20, 20, shape=(2, 1, 4, 6), dtype=np.int8)
@@ -385,13 +440,16 @@ class TestDynamicShape(unittest.TestCase):
                                           [None, None, None, None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({
-        "A": A,
-        "B": B,
-        "a_zero_point": a_zero_point,
-        "b_zero_point": b_zero_point
-    })
-    np.testing.assert_almost_equal(output["Z"], z)
+    # export to tf.saved_model
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(A=A,
+                               B=B,
+                               a_zero_point=a_zero_point,
+                               b_zero_point=b_zero_point)
+    np.testing.assert_almost_equal(tf_model_output[0], z)
 
   def test_non_max_suppression(self):
     if legacy_opset_pre_ver(10):
@@ -437,14 +495,112 @@ class TestDynamicShape(unittest.TestCase):
                                           [None, None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({
-        "boxes": boxes,
-        "scores": scores,
-        "max_output_boxes_per_class": max_output_boxes_per_class,
-        "iou_threshold": iou_threshold,
-        "score_threshold": score_threshold
-    })
-    np.testing.assert_almost_equal(output["selected_indices"], selected_indices)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/non_max_suppression'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(
+        boxes=boxes,
+        scores=scores,
+        max_output_boxes_per_class=max_output_boxes_per_class,
+        iou_threshold=iou_threshold,
+        score_threshold=score_threshold)
+    np.testing.assert_almost_equal(tf_model_output[0], selected_indices)
+
+  def test_non_max_suppression_with_if(self):
+    # if cond
+    #   return NonMaxSuppression suppress by IOU
+    # else
+    #   return NonNaxSuppression suppress by IOU and score
+    boxes = np.array([[[0.0, 0.0, 1.0, 1.0], [0.0, 0.1, 1.0, 1.1],
+                       [0.0, -0.1, 1.0, 0.9], [0.0, 10.0, 1.0, 11.0],
+                       [0.0, 10.1, 1.0, 11.1], [0.0, 100.0, 1.0,
+                                                101.0]]]).astype(np.float32)
+    scores = np.array([[[0.9, 0.75, 0.6, 0.95, 0.5, 0.3]]]).astype(np.float32)
+    max_output_boxes_per_class = np.array([3]).astype(np.int64)
+    iou_threshold = np.array([0.5]).astype(np.float32)
+    score_threshold = np.array([0.4]).astype(np.float32)
+    selected_indices_1 = np.array([[0, 0, 3], [0, 0, 0], [0, 0,
+                                                          5]]).astype(np.int64)
+    selected_indices_2 = np.array([[0, 0, 3], [0, 0, 0]]).astype(np.int64)
+
+    boxes_in = helper.make_tensor_value_info("boxes", TensorProto.FLOAT,
+                                             [None, None, None])
+    scores_in = helper.make_tensor_value_info("scores", TensorProto.FLOAT,
+                                              [None, None, None])
+    max_output_boxes_per_class_in = helper.make_tensor_value_info(
+        "max_output_boxes_per_class", TensorProto.INT64, [None])
+    iou_threshold_in = helper.make_tensor_value_info("iou_threshold",
+                                                     TensorProto.FLOAT, [None])
+    score_threshold_in = helper.make_tensor_value_info("score_threshold",
+                                                       TensorProto.FLOAT,
+                                                       [None])
+    cond_in = helper.make_tensor_value_info('cond', TensorProto.BOOL, [])
+
+    selected_indices_1_out = helper.make_tensor_value_info(
+        "selected_indices_1", TensorProto.INT64, [None, None])
+    selected_indices_2_out = helper.make_tensor_value_info(
+        "selected_indices_2", TensorProto.INT64, [None, None])
+    selected_indices_out = helper.make_tensor_value_info(
+        "selected_indices", TensorProto.INT64, [None, None])
+
+    non_max_suppression_node_1 = helper.make_node(
+        "NonMaxSuppression",
+        ["boxes", "scores", "max_output_boxes_per_class", "iou_threshold"],
+        ["selected_indices_1"],
+        center_point_box=0)
+    non_max_suppression_node_2 = helper.make_node("NonMaxSuppression", [
+        "boxes", "scores", "max_output_boxes_per_class", "iou_threshold",
+        "score_threshold"
+    ], ["selected_indices_2"],
+                                                  center_point_box=0)
+
+    then_graph = helper.make_graph(nodes=[non_max_suppression_node_1],
+                                   name="then_graph",
+                                   inputs=[
+                                       boxes_in, scores_in,
+                                       max_output_boxes_per_class_in,
+                                       iou_threshold_in
+                                   ],
+                                   outputs=[selected_indices_1_out])
+    else_graph = helper.make_graph(nodes=[non_max_suppression_node_2],
+                                   name="then_graph",
+                                   inputs=[
+                                       boxes_in, scores_in,
+                                       max_output_boxes_per_class_in,
+                                       iou_threshold_in, score_threshold_in
+                                   ],
+                                   outputs=[selected_indices_2_out])
+    if_node = helper.make_node('If', ['cond'], ["selected_indices"],
+                               then_branch=then_graph,
+                               else_branch=else_graph)
+    graph_def = helper.make_graph(nodes=[if_node],
+                                  name='test_if',
+                                  inputs=[
+                                      boxes_in, scores_in,
+                                      max_output_boxes_per_class_in,
+                                      iou_threshold_in, score_threshold_in,
+                                      cond_in
+                                  ],
+                                  outputs=[selected_indices_out])
+    tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/non_max_suppression/if'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    for cond, exp in [[True, selected_indices_1], [False, selected_indices_2]]:
+      tf_model_output = tf_model(
+          boxes=boxes,
+          scores=scores,
+          max_output_boxes_per_class=max_output_boxes_per_class,
+          iou_threshold=iou_threshold,
+          score_threshold=score_threshold,
+          cond=cond)
+      np.testing.assert_almost_equal(tf_model_output[0], exp)
 
   def test_scatter_nd(self):
     if legacy_opset_pre_ver(11):
@@ -478,8 +634,14 @@ class TestDynamicShape(unittest.TestCase):
                                           [None, None, None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"data": data, "indices": indices, "updates": updates})
-    np.testing.assert_almost_equal(output["outputs"], ref_output)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/scatter_nd'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(data=data, indices=indices, updates=updates)
+    np.testing.assert_almost_equal(tf_model_output[0], ref_output)
 
   def test_max_pool_2d_dilations_ceil_pads(self):
     if legacy_opset_pre_ver(10):
@@ -526,16 +688,21 @@ class TestDynamicShape(unittest.TestCase):
                                           [None, None, None, None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x})
-
-    np.testing.assert_almost_equal(output["Y"], test_output)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/max_pool_2d_dilations_ceil_pads'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x)
+    np.testing.assert_almost_equal(tf_model_output[0], test_output)
 
   def test_max_pool_with_argmax_2d_dilations_ceil_pads(self):
     if legacy_opset_pre_ver(10):
       raise unittest.SkipTest(
           "ONNX version {} doesn't support dilations nor ceil mode.".format(
               defs.onnx_opset_version()))
- 
+
     kernel_shape = [3, 3]
     strides = [2, 2]
     dilations = [3, 3]
@@ -567,7 +734,13 @@ class TestDynamicShape(unittest.TestCase):
         ])
 
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x})
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/max_pool_with_argmax_2d_dilations_ceil_pads'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x)
 
     test_output, test_ind = py_pool(x,
                                     kernel_shape=kernel_shape,
@@ -577,8 +750,8 @@ class TestDynamicShape(unittest.TestCase):
                                     ceil_mode=ceil_mode,
                                     pooling_type="MAX")
 
-    np.testing.assert_almost_equal(output["Y"], test_output)
-    np.testing.assert_almost_equal(output["Ind"], test_ind)
+    np.testing.assert_almost_equal(tf_model_output[0], test_output)
+    np.testing.assert_almost_equal(tf_model_output[1], test_ind)
 
   def test_average_pool_2d(self):
     kernel_shape = [1, 2]
@@ -611,9 +784,14 @@ class TestDynamicShape(unittest.TestCase):
                                           [None, None, None, None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output = tf_rep.run({"X": x})
-
-    np.testing.assert_almost_equal(output["Y"], test_output)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/average_pool_2d'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x)
+    np.testing.assert_almost_equal(tf_model_output[0], test_output)
 
   def test_max_unpool(self):
     input_shape = [10, 3, 24, 24]
@@ -645,7 +823,13 @@ class TestDynamicShape(unittest.TestCase):
                                           [None, None, None, None])
         ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
-    output_unpool = tf_rep.run({"X": x})
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/max_unpool'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
+    tf_model_output = tf_model(X=x)
 
     test_output = np.zeros(input_shape)
     for i1 in range(0, input_shape[0]):
@@ -660,7 +844,7 @@ class TestDynamicShape(unittest.TestCase):
                   max_ind = (j1, j2)
             j1, j2 = max_ind
             test_output[i1][i2][j1][j2] = max_val
-    np.testing.assert_almost_equal(output_unpool["Y"], test_output)
+    np.testing.assert_almost_equal(tf_model_output[0], test_output)
 
   def test_slice(self):
     # test case 1 with normal inputs
@@ -703,20 +887,20 @@ class TestDynamicShape(unittest.TestCase):
                                             [None, None, None])
           ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/slice'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
 
     if legacy_opset_pre_ver(10):
       x = self._get_rnd_float32(shape=[1000]).reshape([10, 10, 10])
-      output = tf_rep.run({"X": x})
-      np.testing.assert_almost_equal(output["S"], x[0:2, 0:2, 0:2])
+      tf_model_output = tf_model(X=x)
+      np.testing.assert_almost_equal(tf_model_output[0], x[0:2, 0:2, 0:2])
     else:
       x = self._get_rnd_float32(shape=[1000]).reshape([10, 10, 10])
-      output = tf_rep.run({
-          "X": x,
-          "starts": starts,
-          "ends": ends,
-          "axes": axes
-      })
-      np.testing.assert_almost_equal(output["S"], x[0:2, 0:2, 0:2])
+      tf_model_output = tf_model(X=x, starts=starts, ends=ends, axes=axes)
+      np.testing.assert_almost_equal(tf_model_output[0], x[0:2, 0:2, 0:2])
 
     # test case 2 with negative, out-of-bound and default inputs
     axes = [0, 2]
@@ -761,20 +945,24 @@ class TestDynamicShape(unittest.TestCase):
                                             [None, None, None])
           ])
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/slice'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+
     if legacy_opset_pre_ver(10):
       x = self._get_rnd_float32(shape=[1000]).reshape([10, 10, 10])
-      output = tf_rep.run({"X": x})
-      np.testing.assert_almost_equal(output["S"], x[0:-8, :, -7:20])
+      tf_model_output = tf_model(X=x)
+      np.testing.assert_almost_equal(tf_model_output[0], x[0:-8, :, -7:20])
     else:
       x = self._get_rnd_float32(shape=[1000]).reshape([10, 10, 10])
-      output = tf_rep.run({
-          "X": x,
-          "starts": starts,
-          "ends": ends,
-          "axes": axes,
-          "steps": steps
-      })
-      np.testing.assert_almost_equal(output["S"], x[0:-8, :, -7:20])
+      tf_model_output = tf_model(X=x,
+                                 starts=starts,
+                                 ends=ends,
+                                 axes=axes,
+                                 steps=steps)
+      np.testing.assert_almost_equal(tf_model_output[0], x[0:-8, :, -7:20])
 
     # test case 3 with non-default steps
     axes = [0, 1, 2]
@@ -784,14 +972,13 @@ class TestDynamicShape(unittest.TestCase):
 
     if not legacy_opset_pre_ver(10):
       x = self._get_rnd_float32(shape=[1000]).reshape([10, 10, 10])
-      output = tf_rep.run({
-          "X": x,
-          "starts": starts,
-          "ends": ends,
-          "axes": axes,
-          "steps": steps
-      })
-      np.testing.assert_almost_equal(output["S"], x[0:2:2, 0:2:-2, 0:2:-1])
+      tf_model_output = tf_model(X=x,
+                                 starts=starts,
+                                 ends=ends,
+                                 axes=axes,
+                                 steps=steps)
+      np.testing.assert_almost_equal(tf_model_output[0], x[0:2:2, 0:2:-2,
+                                                           0:2:-1])
 
   def test_split(self):
     shape = [12, 12]
@@ -814,13 +1001,29 @@ class TestDynamicShape(unittest.TestCase):
         ])
 
     tf_rep = onnx_graph_to_tensorflow_rep(graph_def)
+    # export to tf.saved_model
+    model_path = 'test_dynamic_shape/split'
+    tf_rep.export_graph(model_path)
+    # load the saved_model back
+    tf_model = tf.saved_model.load(model_path)
+    # run the model
     x = self._get_rnd_float32(shape=shape)
-    output = tf_rep.run({"X": x})
+    tf_model_output = tf_model(X=x)
 
     per_part = shape[axis] // output_count
     split = [per_part] * output_count
-    for a, b in zip(list(output), np.split(x, np.cumsum(split))[:-1]):
+    for a, b in zip(list(tf_model_output), np.split(x, np.cumsum(split))[:-1]):
       np.testing.assert_almost_equal(a, b)
+
+  @classmethod
+  def tearDownClass(cls):
+    # clean up saved model folder
+    try:
+      model_path = 'test_dynamic_shape'
+      shutil.rmtree(model_path)
+    except FileNotFoundError:
+      # the model folder doesn't exist
+      pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Add export_graph and use this graph to run in Tensorflow instead of using tf_rep.run for each dynamic shape testcases to verify our handlers can support unknown shape inputs.
2. Fix conv_mixin to support dynamic shape input for W.
3. Move tf.Variable creation into BackendTFModule.__init__ instead of creating them inside the handler.
4. Update non_max_suppression handler to create the tf.Variable in BackendTFModule.__init__ and use the variable in the handler
5. Fix random_normal_like handler to support dynamic shape input.
6. Fix dilated_pooling to handle unknown input shape.
7. Add ONNX operators count to tf_rep.
8. Minor update on CLI_template.md
Signed-off-by: Winnie Tsang <wtsang@us.ibm.com>