### PR TITLE
Add auto-cast capability into OneHot handler

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,7 +1,7 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: 1150bd009684a0dcd3fdde51f307a6409ceab7ba )|
+|ONNX-Tensorflow Version|Master ( commit id: 9e7b54b1d14aafc4aa6329c12f0ee74226255eca )|
 |ONNX Version|Master ( commit id: 274e8b54e4c11c40a8c0a89599196f5311088b64 )|
 |Tensorflow Version|v2.3.1|
 
@@ -133,7 +133,7 @@ Notes:
 |Reshape|**1**|1|1|1|**5**|5|5|5|5|5|5|5|**13**:small_red_triangle:|Reshape|
 |Resize|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|**11**:small_orange_diamond:|11:small_orange_diamond:|**13**:small_orange_diamond:|Resize|
 |ReverseSequence|-|-|-|-|-|-|-|-|-|**10**|10|10|10|ReverseSequence|
-|RoiAlign|-|-|-|-|-|-|-|-|-|**10**|10|10|10|RoiAlign|
+|RoiAlign|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|RoiAlign|
 |Round|-|-|-|-|-|-|-|-|-|-|**11**|11|11|Round|
 |Scan|-|-|-|-|-|-|-|**8**|**9**|9|**11**|11|11|Scan|
 |Scatter|-|-|-|-|-|-|-|-|**9**|9|**11**\*|11\*|11\*|Scatter|
@@ -202,5 +202,6 @@ Notes:
 	10. mode=nearest, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, nearest_mode=round_prefer_ceil, can use scales or sizes.
 	11. mode=linear, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, can use scales or sizes.
 	- Note (*): The accuracy of your model will go down, if the height and the width of the new sizes(scales * origial sizes) are not in whole numbers.
-9. SplitToSequence: Scalar as the split input not supported.
-10. Upsample: Upsample required 4D input in Tensorflow.
+9. RoiAlign: sampling_ratio <= 0 is not fully supported.
+10. SplitToSequence: Scalar as the split input not supported.
+11. Upsample: Upsample required 4D input in Tensorflow.

--- a/onnx_tf/handlers/backend/onehot.py
+++ b/onnx_tf/handlers/backend/onehot.py
@@ -1,15 +1,45 @@
 import copy
 import tensorflow as tf
 
+from onnx_tf.common import exception
+from onnx_tf.common import data_type
+from onnx_tf.common import sys_config
+from onnx_tf.common.tf_helper import tf_shape
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
-from onnx_tf.common.tf_helper import tf_shape
 
 
 @onnx_op("OneHot")
 @tf_func(tf.one_hot)
 class OneHot(BackendHandler):
+  depth_supported_type = [tf.int32]
+  depth_cast_map = {
+      tf.uint8: tf.int32,
+      tf.uint16: tf.int32,
+      tf.int8: tf.int32,
+      tf.int16: tf.int32
+  }
+
+  @classmethod
+  def args_check(cls, node, **kwargs):
+    # update cast_map base on auto_cast flag
+    cls.depth_cast_map[tf.uint32] = tf.int32 if sys_config.auto_cast else None
+    cls.depth_cast_map[tf.uint64] = tf.int32 if sys_config.auto_cast else None
+    cls.depth_cast_map[tf.int64] = tf.int32 if sys_config.auto_cast else None
+    cls.depth_cast_map[tf.float16] = tf.int32 if sys_config.auto_cast else None
+    cls.depth_cast_map[tf.float32] = tf.int32 if sys_config.auto_cast else None
+    cls.depth_cast_map[tf.float64] = tf.int32 if sys_config.auto_cast else None
+
+    tensor_dict = kwargs["tensor_dict"]
+    depth = tensor_dict[node.inputs[1]]
+    depth_dtype = depth.dtype
+    if depth_dtype in cls.depth_cast_map and cls.depth_cast_map[
+        depth_dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "OneHot input " + node.inputs[1] + " with data type '" +
+          data_type.tf_to_np_str(depth_dtype) + "'",
+          data_type.tf_to_np_str_list(cls.depth_supported_type))
 
   @classmethod
   def process_neg_indices(cls, depth, indices):
@@ -30,13 +60,14 @@ class OneHot(BackendHandler):
     # poocess negative axis
     axis = axis if axis >= 0 else len(tf_shape(indices)) + axis + 1
 
-    # cast indices to tf.int64 and depth to tf.int32 if dtype is not
-    # supported natively by Tensorflow. It is fairly safe since indices
-    # and depth are integers
+    # cast indices to tf.int64 according to the onnx spec
     indices = tf.cast(indices, tf.int64) if indices.dtype not in [
         tf.uint8, tf.int32, tf.int64
     ] else indices
-    depth = tf.cast(depth, tf.int32) if depth.dtype not in [tf.int32] else depth
+
+    # process tf.one_hot unsupported datatype for depth
+    depth = tf.cast(depth, cls.depth_cast_map[
+        depth.dtype]) if depth.dtype in cls.depth_cast_map else depth
 
     # depth can be either a scalar or a 1D tensor of size 1 according
     # to ONNX schema, although operators doc states only scalar.

--- a/onnx_tf/handlers/backend/roi_align.py
+++ b/onnx_tf/handlers/backend/roi_align.py
@@ -5,6 +5,8 @@ from onnx_tf.common import get_data_format
 from onnx_tf.common import get_perm_from_formats
 
 from onnx_tf.handlers.backend_handler import BackendHandler
+from onnx_tf.handlers.handler import partial_support
+from onnx_tf.handlers.handler import ps_description
 from onnx_tf.handlers.handler import onnx_op
 
 
@@ -75,6 +77,8 @@ def crop_and_resize(image,
 
 
 @onnx_op("RoiAlign")
+@partial_support(True)
+@ps_description("sampling_ratio <= 0 is not fully supported.")
 class RoiAlign(BackendHandler):
     @classmethod
     def _common(cls, node, **kwargs):

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -242,6 +242,7 @@ backend_partial_support = {
               '\t- Note (*): The accuracy of your model will go down, if the '
               'height and the width of the new sizes(scales * origial sizes) '
               'are not in whole numbers.',
+    'RoiAlign': 'sampling_ratio <= 0 is not fully supported.',
     'SplitToSequence': 'Scalar as the split input not supported.',
     'Upsample': 'Upsample required 4D input in Tensorflow.'
 }

--- a/test/backend/test_onnx_backend.py
+++ b/test/backend/test_onnx_backend.py
@@ -16,8 +16,10 @@ from onnx_tf.backend import TensorflowBackend
 from onnx_tf.common.legacy import legacy_onnx_pre_ver
 from onnx_tf.common.legacy import legacy_opset_pre_ver
 
+
 def get_onnxtf_supported_ops():
   return opset_version.backend_opset_version
+
 
 def get_onnx_supported_ops():
   onnx_ops_dict = {}
@@ -27,6 +29,7 @@ def get_onnx_supported_ops():
         'deprecated': schema.deprecated
     }
   return onnx_ops_dict
+
 
 # This is a pytest magic variable to load extra plugins
 pytest_plugins = 'onnx.backend.test.report',
@@ -64,10 +67,8 @@ backend_test.exclude(r'test_resize_[a-z,_]*')
 
 # range is using loop in the model test but all the outputs datatype are
 # missing in the body attribute of the loop
-backend_test.exclude(
-    r'test_range_float_type_positive_delta_expanded[a-z,_]*')
-backend_test.exclude(
-    r'test_range_int32_type_negative_delta_expanded[a-z,_]*')
+backend_test.exclude(r'test_range_float_type_positive_delta_expanded[a-z,_]*')
+backend_test.exclude(r'test_range_int32_type_negative_delta_expanded[a-z,_]*')
 
 # skip all the cumsum testcases because all the axis in the testcases
 # are created as a 1-D 1 element tensor, but the spec clearly state
@@ -84,6 +85,9 @@ backend_test.exclude(r'test_loop13_seq[a-z,_]*')
 # TF minimum/maximum do not support uint64 when auto-cast is False (default)
 backend_test.exclude(r'test_min_uint64_[a-z,_]*')
 backend_test.exclude(r'test_max_uint64_[a-z,_]*')
+
+# TF one_hot do not support float32 for depth when auto-cast is False (default)
+backend_test.exclude(r'test_onehot_[a-z,_]*')
 
 if legacy_opset_pre_ver(7):
   backend_test.exclude(r'[a-z,_]*Upsample[a-z,_]*')


### PR DESCRIPTION
1. Add auto-cast capability for input depth in OneHot handler
2. Update support_status for RoiAlign support

Signed-off-by: Winnie Tsang <wtsang@us.ibm.com>