### PR TITLE
Updated Hardmax for opset 13 

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,8 +1,8 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: f64afb48034af7121341f4ba5d6f56e275c5aedb )|
-|ONNX Version|Master ( commit id: a7a0fec7f25cae567429af62b7eaaee1c3f0e247 )|
+|ONNX-Tensorflow Version|Master ( commit id: 5184f393f7e262add46ada96108b2c711db14740 )|
+|ONNX Version|Master ( commit id: 994c6181247d7b419b28889fc57d5817e2089419 )|
 |Tensorflow Version|v2.3.1|
 
 Notes:
@@ -71,7 +71,7 @@ Notes:
 |Greater|**1**|1|1|1|1|1|**7**|7|**9**|9|9|9|**13**|Greater|
 |GreaterOrEqual|-|-|-|-|-|-|-|-|-|-|-|**12**|12|GreaterOrEqual|
 |HardSigmoid|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|HardSigmoid|
-|Hardmax|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**:small_red_triangle:|Hardmax|
+|Hardmax|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**|Hardmax|
 |Identity|**1**|1|1|1|1|1|1|1|1|1|1|1|**13**|Identity|
 |If|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**|If|
 |InstanceNormalization|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|InstanceNormalization|
@@ -133,7 +133,7 @@ Notes:
 |Reshape|**1**|1|1|1|**5**|5|5|5|5|5|5|5|**13**:small_red_triangle:|Reshape|
 |Resize|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|**11**:small_orange_diamond:|11:small_orange_diamond:|**13**:small_orange_diamond:|Resize|
 |ReverseSequence|-|-|-|-|-|-|-|-|-|**10**|10|10|10|ReverseSequence|
-|RoiAlign|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|RoiAlign|
+|RoiAlign|-|-|-|-|-|-|-|-|-|**10**:small_red_triangle:|10:small_red_triangle:|10:small_red_triangle:|10:small_red_triangle:|RoiAlign|
 |Round|-|-|-|-|-|-|-|-|-|-|**11**|11|11|Round|
 |Scan|-|-|-|-|-|-|-|**8**|**9**|9|**11**|11|11|Scan|
 |Scatter|-|-|-|-|-|-|-|-|**9**|9|**11**\*|11\*|11\*|Scatter|
@@ -179,7 +179,7 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|9|Where|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|Xor|
 
-ONNX-TF Supported Operators / ONNX Operators: 118 / 162
+ONNX-TF Supported Operators / ONNX Operators: 119 / 162
 
 Notes:
 1. Cast: Cast string to data types other than float32/float64/int32/int64 is not supported in Tensorflow
@@ -204,4 +204,3 @@ Notes:
 	- Note (*): The accuracy of your model will go down, if the height and the width of the new sizes(scales * origial sizes) are not in whole numbers.
 9. SplitToSequence: Scalar as the split input not supported.
 10. Upsample: Upsample required 4D input in Tensorflow.
-11. RoiAlign: sampling_ratio <= 0 if not fully supported.

--- a/onnx_tf/handlers/backend/hardmax.py
+++ b/onnx_tf/handlers/backend/hardmax.py
@@ -14,18 +14,33 @@ class Hardmax(BackendHandler):
   @classmethod
   def _common(cls, node, **kwargs):
     x = kwargs["tensor_dict"][node.inputs[0]]
-    axis = node.attrs.get("axis", 1)
-    axis = axis if axis >= 0 else len(np.shape(x)) + axis
 
-    if axis == len(np.shape(x)) - 1:
-      return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    if cls.SINCE_VERSION < 13:
+      axis = node.attrs.get("axis", 1)
+      axis = axis if axis >= 0 else len(np.shape(x)) + axis
 
-    shape = tf.shape(x)
-    cal_shape = (tf.reduce_prod(shape[0:axis]),
-                 tf.reduce_prod(shape[axis:tf.size(shape)]))
-    x = tf.reshape(x, cal_shape)
+      if axis == len(np.shape(x)) - 1:
+        return [cls.make_tensor_from_onnx_node(node, **kwargs)]
 
-    return [tf.reshape(tfa.seq2seq.hardmax(x), shape)]
+      shape = tf.shape(x)
+      cal_shape = (tf.reduce_prod(shape[0:axis]),
+                   tf.reduce_prod(shape[axis:tf.size(shape)]))
+      x = tf.reshape(x, cal_shape)
+      return [tf.reshape(tfa.seq2seq.hardmax(x), shape)]
+
+    else: # opset 13
+      axis = node.attrs.get("axis", -1) # default for axis is -1 in opset 13
+      axis = axis if axis >= 0 else len(np.shape(x)) + axis
+
+      if axis == len(np.shape(x)) - 1:
+        return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+
+      perm1 = tf.range(0, axis)
+      perm2 = tf.range(axis + 1, len(tf.shape(x)) - 1)
+      perm = tf.concat([perm1, [len(tf.shape(x)) - 1], perm2, [axis]], -1)
+      x = tf.transpose(x, perm)
+
+      return [tf.transpose(tfa.seq2seq.hardmax(x), perm)]
 
   @classmethod
   def version_1(cls, node, **kwargs):
@@ -33,4 +48,8 @@ class Hardmax(BackendHandler):
 
   @classmethod
   def version_11(cls, node, **kwargs):
+    return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
     return cls._common(node, **kwargs)

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -64,7 +64,7 @@ backend_opset_version = {
     'Greater': [1, 7, 9, 13],
     'GreaterOrEqual': [12],
     'HardSigmoid': [1, 6],
-    'Hardmax': [1, 11],
+    'Hardmax': [1, 11, 13],
     'Identity': [1, 13],
     'If': [1, 11, 13],
     'ImageScaler': [1],


### PR DESCRIPTION
The only change from opset 11 to 13 was support bfloat16 and also the default for axis is -1 in opset 13 as opposed to 1 in opset 11.

It appears that the implementation of converting to a 2d, doing a hardmax, and reshaping the
result did not really work. I  have changed the implementation to be transpose based and I
flip the result.

All tests pass.

Signed-off-by: Shahir A. Daya <sdaya@ca.ibm.com>