### PR TITLE
Fix auto cast for data type downcast

### DIFF
--- a/onnx_tf/handlers/backend/cumsum.py
+++ b/onnx_tf/handlers/backend/cumsum.py
@@ -13,11 +13,13 @@ from onnx_tf.common import data_type
 @tf_func(tf.math.cumsum)
 class CumSum(BackendHandler):
   cast_map = {tf.uint32: tf.int64}
-  cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
   supported_types = [tf.int32, tf.int64, tf.float32, tf.float64]
 
   @classmethod
   def args_check(cls, node, **kwargs):
+    # update cast map based on the auto_cast config option
+    cls.cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+
     x = kwargs["tensor_dict"][node.inputs[0]]
 
     # throw an error if the data type is not natively supported by

--- a/onnx_tf/handlers/backend/equal.py
+++ b/onnx_tf/handlers/backend/equal.py
@@ -12,7 +12,6 @@ import onnx_tf.common.data_type as data_type
 @tf_func(tf.equal)
 class Equal(ComparisonMixin, BackendHandler):
   cast_map = {tf.uint16: tf.int32, tf.uint32: tf.int64}
-  cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
   supported_types = [
       tf.bool, tf.uint8, tf.int8, tf.int16, tf.int32, tf.int64, tf.float16,
       tf.float32, tf.float64, tf.bfloat16
@@ -20,6 +19,9 @@ class Equal(ComparisonMixin, BackendHandler):
 
   @classmethod
   def args_check(cls, node, **kwargs):
+    # update cast map based on the auto_cast config option
+    cls.cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+
     x = kwargs["tensor_dict"][node.inputs[0]]
 
     # throw an error if the data type is not natively supported by

--- a/onnx_tf/handlers/backend/min.py
+++ b/onnx_tf/handlers/backend/min.py
@@ -19,11 +19,14 @@ class Min(BackendHandler):
       tf.int8: tf.int32,
       tf.int16: tf.int32
   }
-  cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
 
   @classmethod
   def args_check(cls, node, **kwargs):
+    # update cast map based on the auto_cast config option
+    cls.cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+
     inp_dtype = kwargs["tensor_dict"][node.inputs[0]].dtype
+
     if inp_dtype in cls.cast_map and cls.cast_map[inp_dtype] is None:
       exception.DTYPE_NOT_CAST_EXCEPT(
           "Min input " + node.inputs[0] + " with data type '" +

--- a/onnx_tf/handlers/backend/mod.py
+++ b/onnx_tf/handlers/backend/mod.py
@@ -17,13 +17,15 @@ class Mod(ArithmeticMixin, BackendHandler):
       tf.int8: tf.int32,
       tf.int16: tf.int32
   }
-  cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
   supported_types = [
       tf.int32, tf.int64, tf.float16, tf.float32, tf.float64, tf.bfloat16
   ]
 
   @classmethod
   def args_check(cls, node, **kwargs):
+    # update cast map based on the auto_cast config option
+    cls.cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+
     x = kwargs["tensor_dict"][node.inputs[0]]
     y = kwargs["tensor_dict"][node.inputs[1]]
 

--- a/onnx_tf/handlers/backend/pow.py
+++ b/onnx_tf/handlers/backend/pow.py
@@ -20,11 +20,13 @@ class Pow(BasicMathMixin, BackendHandler):
       tf.int8: tf.int16,
       tf.int16: tf.int32
   }
-  y_cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
   supported_types = [tf.int32, tf.int64, tf.float16, tf.float32, tf.float64]
 
   @classmethod
   def args_check(cls, node, **kwargs):
+    # update cast map based on the auto_cast config option
+    cls.y_cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+
     y = kwargs["tensor_dict"][node.inputs[1]]
 
     # throw an error if the data type is not natively supported by

--- a/onnx_tf/handlers/backend/resize.py
+++ b/onnx_tf/handlers/backend/resize.py
@@ -48,19 +48,21 @@ class Resize(BackendHandler):
       tf.float32, tf.float64, tf.bfloat16
   ]
   x_cast_map = {tf.uint32: tf.int64, tf.bool: None, tf.string: None}
-  x_cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
-  x_cast_map[tf.complex64] = tf.float64 if sys_config.auto_cast else None
-  x_cast_map[tf.complex128] = tf.float64 if sys_config.auto_cast else None
   cr_x_supported_types = x_supported_types
   cr_x_supported_types.remove(tf.bfloat16)
   cr_x_cast_map = x_cast_map
   cr_x_cast_map[tf.bfloat16] = tf.float32
   roi_supported_types = [tf.float32]
   roi_cast_map = {tf.float16: tf.float32}
-  roi_cast_map[tf.float64] = tf.float32 if sys_config.auto_cast else None
 
   @classmethod
   def args_check(cls, node, **kwargs):
+    # update cast maps based on the auto_cast config option
+    cls.x_cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+    cls.x_cast_map[tf.complex64] = tf.float64 if sys_config.auto_cast else None
+    cls.x_cast_map[tf.complex128] = tf.float64 if sys_config.auto_cast else None
+    cls.roi_cast_map[tf.float64] = tf.float32 if sys_config.auto_cast else None
+
     x = kwargs["tensor_dict"][node.inputs[0]]
     x_shape = x.get_shape().as_list()
     x_dtype = x.dtype


### PR DESCRIPTION
Fix auto cast for data type downcast by moving the auto-cast
check to args_check. Also add a simple test to verify the user
argument is applied for downcast when needed.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>