### PR TITLE
Backport data type support for clip and mod

### DIFF
--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,8 +1,8 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: 6b9e76d6fca74d5ddbf47049b9670120abaaf70f )|
-|ONNX Version|Master ( commit id: 0c070abb0c40fec649f81a73a75b0098662ec486 )|
+|ONNX-Tensorflow Version|Master ( commit id: 92ef9e1944210a97b851c4fee77913dcbe26a59f )|
+|ONNX Version|v1.7.0|
 |Tensorflow Version|v1.15.0|
 
 Notes:
@@ -33,7 +33,7 @@ Notes:
 |Cast|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**9**:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|9:small_orange_diamond:|Cast|
 |Ceil|**1**|1|1|1|1|**6**|6|6|6|6|6|6|Ceil|
 |Celu|-|-|-|-|-|-|-|-|-|-|-|**12**:small_red_triangle:|Celu|
-|Clip|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**6**:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|6:small_orange_diamond:|**11**:small_orange_diamond:|**12**:small_orange_diamond:|Clip|
+|Clip|**1**|1|1|1|1|**6**|6|6|6|6|**11**|**12**|Clip|
 |Compress|-|-|-|-|-|-|-|-|**9**|9|**11**|11|Compress|
 |Concat|**1**|1|1|**4**|4|4|4|4|4|4|**11**|11|Concat|
 |ConcatFromSequence|-|-|-|-|-|-|-|-|-|-|**11**:small_red_triangle:|11:small_red_triangle:|ConcatFromSequence|
@@ -96,7 +96,7 @@ Notes:
 |Mean|**1**|1|1|1|1|**6**|6|**8**|8|8|8|8|Mean|
 |MeanVarianceNormalization|-|-|-|-|-|-|-|-|**9**|9|9|9|MeanVarianceNormalization|
 |Min|**1**|1|1|1|1|**6**|6|**8**|8|8|8|**12**|Min|
-|Mod|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|Mod|
+|Mod|-|-|-|-|-|-|-|-|-|**10**|10|10|Mod|
 |Mul|**1**|1|1|1|1|**6**|**7**|7|7|7|7|7|Mul|
 |Multinomial|-|-|-|-|-|-|**7**:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|7:small_red_triangle:|Multinomial|
 |Neg|**1**|1|1|1|1|**6**|6|6|6|6|6|6|Neg|
@@ -133,7 +133,7 @@ Notes:
 |Reshape|**1**|1|1|1|**5**|5|5|5|5|5|5|5|Reshape|
 |Resize|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|**11**:small_orange_diamond:|11:small_orange_diamond:|Resize|
 |ReverseSequence|-|-|-|-|-|-|-|-|-|**10**|10|10|ReverseSequence|
-|RoiAlign|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|RoiAlign|
+|RoiAlign|-|-|-|-|-|-|-|-|-|**10**|10|10|RoiAlign|
 |Round|-|-|-|-|-|-|-|-|-|-|**11**|11|Round|
 |Scan|-|-|-|-|-|-|-|**8**|**9**|9|**11**|11|Scan|
 |Scatter|-|-|-|-|-|-|-|-|**9**|9|**11**\*|11\*|Scatter|
@@ -183,17 +183,15 @@ ONNX-TF Supported Operators / ONNX Operators: 148 / 162
 
 Notes:
 1. Cast: Cast string to float32/float64/int32/int64 are not supported in Tensorflow.
-2. Clip: Clip input in uint64 is not supported in Tensorflow.
-3. ConvTranspose: ConvTranspose with dilations != 1, or transposed convolution for 4D or higher are not supported in Tensorflow.
-4. CumSum: CumSum inputs in uint32/uint64 are not supported in Tensorflow.
-5. Equal: Equal inputs in uint16/uint32/uint64 are not supported in Tensorflow.
-6. GRU: GRU with clip or GRU with linear_before_reset, or GRU not using sigmoid for z and r, or GRU using Elu as the activation function with alpha != 1, or GRU using HardSigmoid as the activation function with alpha != 0.2 or beta != 0.5 are not supported in TensorFlow.
-7. LSTM: LSTM not using sigmoid for `f`, or LSTM not using the same activation for `g` and `h` are not supported in Tensorflow.
-8. MaxPool: MaxPoolWithArgmax with pad is None or incompatible mode, or MaxPoolWithArgmax with 4D or higher input, orMaxPoolWithArgmax with column major are not supported in Tensorflow.
-9. Mod: Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 are not supported in Tensorflow.
-10. OneHot: OneHot indices in uint16/uint32/uint64/int8/int16/float16/float/double, or OneHot depth in uint8/uint16/uint32/uint64/int8/int16/int64/float16/float/double are not supported in Tensorflow.
-11. RNN: RNN with clip is not supported in Tensorflow.
-12. Resize: Resize required 4D input in Tensorflow. For opset 11, only the following attributes and inputs conbination are supported in Tensorflow:
+2. ConvTranspose: ConvTranspose with dilations != 1, or transposed convolution for 4D or higher are not supported in Tensorflow.
+3. CumSum: CumSum inputs in uint32/uint64 are not supported in Tensorflow.
+4. Equal: Equal inputs in uint16/uint32/uint64 are not supported in Tensorflow.
+5. GRU: GRU with clip or GRU with linear_before_reset, or GRU not using sigmoid for z and r, or GRU using Elu as the activation function with alpha != 1, or GRU using HardSigmoid as the activation function with alpha != 0.2 or beta != 0.5 are not supported in TensorFlow.
+6. LSTM: LSTM not using sigmoid for `f`, or LSTM not using the same activation for `g` and `h` are not supported in Tensorflow.
+7. MaxPool: MaxPoolWithArgmax with pad is None or incompatible mode, or MaxPoolWithArgmax with 4D or higher input, orMaxPoolWithArgmax with column major are not supported in Tensorflow.
+8. OneHot: OneHot indices in uint16/uint32/uint64/int8/int16/float16/float/double, or OneHot depth in uint8/uint16/uint32/uint64/int8/int16/int64/float16/float/double are not supported in Tensorflow.
+9. RNN: RNN with clip is not supported in Tensorflow.
+10. Resize: Resize required 4D input in Tensorflow. For opset 11, only the following attributes and inputs conbination are supported in Tensorflow:
 	1. mode=nearest, coordinate_transformation_mode=align_corners, nearest_mode=round_prefer_ceil, can use scales(*) or sizes.
 	2. mode=nearest, coordinate_transformation_mode=asymmetric, nearest_mode=floor, can use scales(*) or sizes.
 	3. mode=nearest, coordinate_transformation_mode=tf_half_pixel_for_nn, nearest_mode=floor, can use scales(*) or sizes.
@@ -206,5 +204,4 @@ Notes:
 	10. mode=nearest, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, nearest_mode=round_prefer_ceil, can use scales or sizes.
 	11. mode=linear, coordinate_transformation_mode=tf_crop_and_resize, extrapolation_value=any_float_value, can use scales or sizes.
 	- Note (*): The accuracy of your model will go down, if the height and the width of the new sizes(scales * origial sizes) are not in whole numbers.
-13. Upsample: Upsample required 4D input in Tensorflow.
-14. RoiAlign: sampling_ratio > 0 if not fully supported.
+11. Upsample: Upsample required 4D input in Tensorflow.

--- a/onnx_tf/handlers/backend/mod.py
+++ b/onnx_tf/handlers/backend/mod.py
@@ -1,38 +1,68 @@
 import tensorflow as tf
 
 from onnx_tf.common import exception
+from onnx_tf.common import sys_config
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
-from onnx_tf.handlers.handler import partial_support
-from onnx_tf.handlers.handler import ps_description
 from .math_mixin import ArithmeticMixin
+import onnx_tf.common.data_type as data_type
 
 
 @onnx_op("Mod")
-@partial_support(True)
-@ps_description("Mod Dividend or Divisor in " +
-                "int8/int16/uint8/uint16/uint32/uint64 " +
-                "are not supported in Tensorflow.")
 class Mod(ArithmeticMixin, BackendHandler):
+  cast_map = {
+      tf.uint8: tf.int32,
+      tf.uint16: tf.int32,
+      tf.uint32: tf.int64,
+      tf.int8: tf.int32,
+      tf.int16: tf.int32
+  }
+  supported_types = [
+      tf.int32, tf.int64, tf.float16, tf.float32, tf.float64, tf.bfloat16
+  ]
 
   @classmethod
   def args_check(cls, node, **kwargs):
-    unsupported_dtype = [
-        tf.int8, tf.int16, tf.uint8, tf.uint16, tf.uint32, tf.uint64
-    ]
+    # update cast map based on the auto_cast config option
+    cls.cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+
     x = kwargs["tensor_dict"][node.inputs[0]]
     y = kwargs["tensor_dict"][node.inputs[1]]
-    if x.dtype in unsupported_dtype:
-      exception.OP_UNSUPPORTED_EXCEPT(
-          "Mod Dividend in " + str(x.dtype), "Tensorflow")
-    if y.dtype in unsupported_dtype:
-      exception.OP_UNSUPPORTED_EXCEPT(
-          "Mod Divisor in " + str(y.dtype), "Tensorflow")
+
+    # throw an error if the data type is not natively supported by
+    # Tensorflow, cannot be safely cast, and auto-cast option is False
+    if x.dtype in cls.cast_map and cls.cast_map[x.dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "Mod input " + node.inputs[0] + " with data type '" +
+          data_type.tf_to_np_str(x.dtype) + "'",
+          data_type.tf_to_np_str_list(cls.supported_types))
+
+    # throw an error if inputs A and B are not in the same data type
+    if x.dtype != y.dtype:
+      exception.OP_UNSUPPORTED_EXCEPT("Mod with inputs in different data types",
+                                      "Tensorflow")
+  @classmethod
+  def _common(cls, node, **kwargs):
+    x = kwargs["tensor_dict"][node.inputs[0]]
+    y = kwargs["tensor_dict"][node.inputs[1]]
+    x_dtype = x.dtype
+    y_dtype = y.dtype
+    fmod = node.attrs.get("fmod", 0)
+
+    # cast inputs if not natively support by Tensorflow API
+    need_cast = x_dtype in cls.cast_map
+    x = tf.cast(x, cls.cast_map[x_dtype]) if need_cast else x
+    y = tf.cast(y, cls.cast_map[y_dtype]) if need_cast else y
+
+    tf_func = tf.truncatemod if fmod == 1 else tf.math.floormod
+    z = cls.make_tensor_from_onnx_node(node,
+                                       tf_func=tf_func,
+                                       inputs=[x, y],
+                                       **kwargs)
+    z = tf.cast(z, x_dtype) if need_cast else z
+
+    return [z]
 
   @classmethod
   def version_10(cls, node, **kwargs):
-    fmod = node.attrs.get("fmod", 0)
-    tf_func = tf.floormod
-    if fmod == 1:
-      tf_func = tf.truncatemod
-    return [cls.make_tensor_from_onnx_node(node, tf_func=tf_func, **kwargs)]
+    return cls._common(node, **kwargs)

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -95,7 +95,7 @@ backend_opset_version = {
     'Mean': [1, 6, 8],
     'MeanVarianceNormalization': [1, 9],
     'Min': [1, 6, 8, 12],
-    'Mod': [10],
+    'Mod': [10, 13],
     'Momentum': [],
     'Mul': [1, 6, 7],
     'Multinomial': [],
@@ -191,7 +191,6 @@ backend_opset_version = {
 backend_partial_support = {
     'Cast': 'Cast string to float32/float64/int32/int64 are not supported in '
             'Tensorflow.',
-    'Clip': 'Clip input in uint64 is not supported in Tensorflow.',
     'ConvTranspose': 'ConvTranspose with dilations != 1, or transposed '
                      'convolution for 4D or higher are not supported in '
                      'Tensorflow.',
@@ -208,8 +207,6 @@ backend_partial_support = {
     'MaxPool': 'MaxPoolWithArgmax with pad is None or incompatible mode, or '
                'MaxPoolWithArgmax with 4D or higher input, orMaxPoolWithArgmax '
                'with column major are not supported in Tensorflow.',
-    'Mod': 'Mod Dividend or Divisor in int8/int16/uint8/uint16/uint32/uint64 '
-           'are not supported in Tensorflow.',
     'OneHot': 'OneHot indices in '
               'uint16/uint32/uint64/int8/int16/float16/float/double, or OneHot '
               'depth in '

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -2206,6 +2206,12 @@ class TestNode(unittest.TestCase):
     node_def = helper.make_node("Mod", ["X", "Y"], ["Z"], fmod=1)
     output = run_node(node_def, [x, y])
     np.testing.assert_almost_equal(output["Z"], np.fmod(x, y))
+    # test data cast for int16
+    x = self._get_rnd_int(shape=[5, 5], low=1, high=100, dtype=np.int16)
+    y = self._get_rnd_int(shape=[5, 5], low=1, high=100, dtype=np.int16)
+    node_def = helper.make_node("Mod", ["X", "Y"], ["Z"], fmod=0)
+    output = run_node(node_def, [x, y])
+    np.testing.assert_almost_equal(output["Z"], np.mod(x, y))
 
   def test_neg(self):
     node_def = helper.make_node("Neg", ["X"], ["Y"])


### PR DESCRIPTION
Backport data type support for clip and mod using the
auto-cast feature and add a test cast in test_node.py.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>