### PR TITLE
Backport cumsum, equal support, attribute name fix

### DIFF
--- a/onnx_tf/common/data_type.py
+++ b/onnx_tf/common/data_type.py
@@ -77,6 +77,5 @@ def any_dtype_to_onnx_dtype(np_dtype=None, tf_dtype=None, onnx_dtype=None):
 def tf_to_np_str(from_type):
   return mapping.TENSOR_TYPE_TO_NP_TYPE[int(tf2onnx(from_type))].name
 
-
 def tf_to_np_str_list(from_list):
   return [tf_to_np_str(from_list[i]) for i in range(len(from_list))]

--- a/onnx_tf/handlers/backend/cumsum.py
+++ b/onnx_tf/handlers/backend/cumsum.py
@@ -3,38 +3,45 @@ import tensorflow as tf
 from onnx_tf.common import exception
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
-from onnx_tf.handlers.handler import partial_support
-from onnx_tf.handlers.handler import ps_description
 from onnx_tf.handlers.handler import tf_func
+from onnx_tf.common import sys_config
+from onnx_tf.common import exception
+from onnx_tf.common import data_type
 
 
 @onnx_op("CumSum")
 @tf_func(tf.math.cumsum)
-@partial_support(True)
-@ps_description(
-    "CumSum inputs in uint32/uint64 " + "are not supported in Tensorflow."
-)
 class CumSum(BackendHandler):
+  cast_map = {tf.uint32: tf.int64}
+  supported_types = [tf.int32, tf.int64, tf.float32, tf.float64]
+
   @classmethod
   def args_check(cls, node, **kwargs):
-    supported_dtype = [
-        tf.bfloat16, tf.half, tf.float32, tf.float64, tf.uint8, tf.uint16,
-        tf.int8, tf.int16, tf.int32, tf.int64, tf.complex64, tf.complex128
-    ]
+    # update cast map based on the auto_cast config option
+    cls.cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+
     x = kwargs["tensor_dict"][node.inputs[0]]
-    if x.dtype not in supported_dtype:
-      exception.OP_UNSUPPORTED_EXCEPT(
-          "CumSum input in " + str(x.dtype) + " which", "Tensorflow")
+
+    # throw an error if the data type is not natively supported by
+    # Tensorflow, cannot be safely cast, and auto-cast option is False
+    if x.dtype in cls.cast_map and cls.cast_map[x.dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "CumSum input " + node.inputs[0] + " with data type '" +
+          data_type.tf_to_np_str(x.dtype) + "'",
+          data_type.tf_to_np_str_list(cls.supported_types))
 
   @classmethod
   def version_11(cls, node, **kwargs):
-    tensor_dict = kwargs["tensor_dict"]
-    x = tensor_dict[node.inputs[0]]
+    x = kwargs["tensor_dict"][node.inputs[0]]
+
+    # handle data types that are not natively supported by Tensorflow
+    dtype = x.dtype
+    x = tf.cast(x, cls.cast_map[dtype]) if dtype in cls.cast_map else x
     inputs = [x]
 
     if len(node.inputs) > 1:
       # optional 0-D tensor, range [-rank(x), rank(x)-1]
-      axis = tensor_dict[node.inputs[1]]
+      axis = kwargs["tensor_dict"][node.inputs[1]]
       inputs.append(axis)
 
     attrs = {
@@ -42,5 +49,5 @@ class CumSum(BackendHandler):
         "reverse": bool(node.attrs.get("reverse", 0))
     }
 
-    return [cls.make_tensor_from_onnx_node(node, inputs=inputs, attrs=attrs)]
-
+    result = cls.make_tensor_from_onnx_node(node, inputs=inputs, attrs=attrs)
+    return [tf.cast(result, dtype) if dtype in cls.cast_map else result]

--- a/onnx_tf/handlers/backend/equal.py
+++ b/onnx_tf/handlers/backend/equal.py
@@ -3,30 +3,47 @@ import tensorflow as tf
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
-from onnx_tf.handlers.handler import partial_support
-from onnx_tf.handlers.handler import ps_description
 from .control_flow_mixin import ComparisonMixin
-
+from onnx_tf.common import sys_config
+from onnx_tf.common import exception
+import onnx_tf.common.data_type as data_type
 
 @onnx_op("Equal")
 @tf_func(tf.equal)
-@partial_support(True)
-@ps_description("Equal inputs in uint16/uint32/uint64 " +
-                "are not supported in Tensorflow.")
 class Equal(ComparisonMixin, BackendHandler):
+  cast_map = {tf.uint16: tf.int32, tf.uint32: tf.int64}
+  supported_types = [
+      tf.bool, tf.uint8, tf.int8, tf.int16, tf.int32, tf.int64, tf.float16,
+      tf.float32, tf.float64
+  ]
 
   @classmethod
   def args_check(cls, node, **kwargs):
-    supported_dtype = [
-        tf.bfloat16, tf.half, tf.float32, tf.float64, tf.uint8,
-        tf.int8, tf.int16, tf.int32, tf.int64, tf.complex64,
-        tf.quint8, tf.qint8, tf.qint32, tf.string, tf.bool, 
-        tf.complex128
-    ]
+    # update cast map based on the auto_cast config option
+    cls.cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
+
     x = kwargs["tensor_dict"][node.inputs[0]]
-    if x.dtype not in supported_dtype:
-      exception.OP_UNSUPPORTED_EXCEPT(
-          "Equal inputs in " + str(x.dtype) + " which", "Tensorflow")
+
+    # throw an error if the data type is not natively supported by
+    # Tensorflow, cannot be safely cast, and auto_cast option is False
+    if x.dtype in cls.cast_map and cls.cast_map[x.dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "Equal input " + node.inputs[0] + " with data type '" +
+          data_type.tf_to_np_str(x.dtype) + "'",
+          data_type.tf_to_np_str_list(cls.supported_types))
+
+  @classmethod
+  def _common(cls, node, **kwargs):
+
+    def dtype_cast(x, y):
+      x = tf.cast(x, cls.cast_map[x.dtype]) if x.dtype in cls.cast_map else x
+      y = tf.cast(y, cls.cast_map[y.dtype]) if y.dtype in cls.cast_map else y
+      return x, y
+
+    # handle data types that are not natively supported by Tensorflow
+    x, y = dtype_cast(kwargs["tensor_dict"][node.inputs[0]],
+                      kwargs["tensor_dict"][node.inputs[1]])
+    return [cls.make_tensor_from_onnx_node(node, inputs=[x, y])]
 
   @classmethod
   def version_1(cls, node, **kwargs):
@@ -34,8 +51,8 @@ class Equal(ComparisonMixin, BackendHandler):
 
   @classmethod
   def version_7(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    return cls._common(node, **kwargs)
 
   @classmethod
   def version_11(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    return cls._common(node, **kwargs)

--- a/onnx_tf/handlers/backend_handler.py
+++ b/onnx_tf/handlers/backend_handler.py
@@ -177,6 +177,10 @@ class BackendHandler(Handler):
         params = inspect.getargspec(tf_func).args
 
     attrs = cls._process_attrs(attrs)
+
+    if "name" in attrs.keys():
+      attrs["name"] = "onnx_tf_prefix_" + attrs["name"]
+
     attrs = {p: v for p, v in attrs.items() if p in params}
     kwargs = dict(zip(params, inputs))
     ambiguous_arguments = any(kwargs.get(p) is not None and v is not None

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -556,6 +556,11 @@ class TestNode(unittest.TestCase):
     y = np.cumsum(x, axis).astype(np.int32)
     output = run_node(node_def, [x, axis])
     np.testing.assert_almost_equal(output["y"], y)
+    # test data types that are not natively supported by Tensorflow
+    x = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.uint32)
+    y = np.cumsum(x, axis).astype(np.uint32)
+    output = run_node(node_def, [x, axis])
+    np.testing.assert_almost_equal(output["y"], y)
 
   def test_depth_to_space(self):
     for device in self._get_device_list():
@@ -664,6 +669,16 @@ class TestNode(unittest.TestCase):
     output = run_node(node_def, [x, y])
     np.testing.assert_equal(output["Z"], np.equal(x,
                                                   np.reshape(y, [1, 3, 3, 1])))
+    # test data types that are not natively supported by Tensorflow
+    x = np.arange(8).reshape((2, 2, 2)).astype(np.uint16)
+    y = np.arange(8).reshape((2, 2, 2)).astype(np.uint16)
+    output = run_node(node_def, [x, y])
+    np.testing.assert_equal(output["Z"], np.equal(x, y))
+
+    x = np.arange(8).reshape((2, 2, 2)).astype(np.uint64)
+    y = np.arange(8).reshape((2, 2, 2)).astype(np.uint64)
+    with np.testing.assert_raises(RuntimeError):
+      output = run_node(node_def, [x, y])
 
   def test_erf(self):
     if legacy_opset_pre_ver(9):


### PR DESCRIPTION
This backport PR includes
1. data type cast support for cumsum (#706)
2. data type cast support for equal (#706)
3. unit tests for cumsum and equal (#706)
4. attribute name fix (#348)
5. bfloat16 support (#706)

Signed-off-by: Chin Huang <chhuang@us.ibm.com>