### PR TITLE
Minor change in Onehot auto-cast support

### DIFF
--- a/onnx_tf/handlers/backend/onehot.py
+++ b/onnx_tf/handlers/backend/onehot.py
@@ -13,27 +13,49 @@ from onnx_tf.handlers.handler import tf_func
 @onnx_op("OneHot")
 @tf_func(tf.one_hot)
 class OneHot(BackendHandler):
+  indices_supported_type = [tf.uint8, tf.int32, tf.int64]
+  indices_cast_map = {
+      tf.uint16: tf.int32,
+      tf.uint32: tf.int64,
+      tf.int8: tf.int32,
+      tf.int16: tf.int32,
+      # ONNX spec state that all non-integer type will be casted to int64 before use
+      tf.float16: tf.int64,
+      tf.float32: tf.int64,
+      tf.float64: tf.int64
+  }
   depth_supported_type = [tf.int32]
   depth_cast_map = {
       tf.uint8: tf.int32,
       tf.uint16: tf.int32,
       tf.int8: tf.int32,
-      tf.int16: tf.int32
+      tf.int16: tf.int32,
+      # ONNX spec state that all non-integer type will be casted to int64 before use
+      # but TF only support int32 for depth so will cast to int32
+      tf.float16: tf.int32,
+      tf.float32: tf.int32,
+      tf.float64: tf.int32
   }
 
   @classmethod
   def args_check(cls, node, **kwargs):
     # update cast_map base on auto_cast flag
+    cls.indices_cast_map[tf.uint64] = tf.int64 if sys_config.auto_cast else None
     cls.depth_cast_map[tf.uint32] = tf.int32 if sys_config.auto_cast else None
     cls.depth_cast_map[tf.uint64] = tf.int32 if sys_config.auto_cast else None
     cls.depth_cast_map[tf.int64] = tf.int32 if sys_config.auto_cast else None
-    cls.depth_cast_map[tf.float16] = tf.int32 if sys_config.auto_cast else None
-    cls.depth_cast_map[tf.float32] = tf.int32 if sys_config.auto_cast else None
-    cls.depth_cast_map[tf.float64] = tf.int32 if sys_config.auto_cast else None
 
     tensor_dict = kwargs["tensor_dict"]
+    indices = tensor_dict[node.inputs[0]]
     depth = tensor_dict[node.inputs[1]]
+    indices_dtype = indices.dtype
     depth_dtype = depth.dtype
+    if indices_dtype in cls.indices_cast_map and cls.indices_cast_map[
+        indices_dtype] is None:
+      exception.DTYPE_NOT_CAST_EXCEPT(
+          "OneHot input " + node.inputs[0] + " with data type '" +
+          data_type.tf_to_np_str(indices_dtype) + "'",
+          data_type.tf_to_np_str_list(cls.indices_supported_type))
     if depth_dtype in cls.depth_cast_map and cls.depth_cast_map[
         depth_dtype] is None:
       exception.DTYPE_NOT_CAST_EXCEPT(
@@ -44,8 +66,7 @@ class OneHot(BackendHandler):
   @classmethod
   def process_neg_indices(cls, depth, indices):
     indices_dtype = indices.dtype
-    depth_dtype = depth.dtype
-    indices = tf.math.floormod(tf.add(tf.cast(indices, depth_dtype), depth),
+    indices = tf.math.floormod(tf.add(tf.cast(indices, depth.dtype), depth),
                                depth)
     return tf.cast(indices, indices_dtype)
 
@@ -60,10 +81,9 @@ class OneHot(BackendHandler):
     # poocess negative axis
     axis = axis if axis >= 0 else len(tf_shape(indices)) + axis + 1
 
-    # cast indices to tf.int64 according to the onnx spec
-    indices = tf.cast(indices, tf.int64) if indices.dtype not in [
-        tf.uint8, tf.int32, tf.int64
-    ] else indices
+    # process tf.one_hot unsupported datatype for indices
+    indices = tf.cast(indices, cls.indices_cast_map[
+        indices.dtype]) if indices.dtype in cls.indices_cast_map else indices
 
     # process tf.one_hot unsupported datatype for depth
     depth = tf.cast(depth, cls.depth_cast_map[

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -2401,6 +2401,8 @@ class TestNode(unittest.TestCase):
                           np.uint16(depth), values])
     np.testing.assert_equal(output['y'], y)
     self.assertRaises(RuntimeError, run_node, node_def,
+                      [indices.astype(np.uint64), depth, values])
+    self.assertRaises(RuntimeError, run_node, node_def,
                       [indices, np.int64(depth), values])
 
     # with axis

--- a/test/backend/test_onnx_backend.py
+++ b/test/backend/test_onnx_backend.py
@@ -86,9 +86,6 @@ backend_test.exclude(r'test_loop13_seq[a-z,_]*')
 backend_test.exclude(r'test_min_uint64_[a-z,_]*')
 backend_test.exclude(r'test_max_uint64_[a-z,_]*')
 
-# TF one_hot do not support float32 for depth when auto-cast is False (default)
-backend_test.exclude(r'test_onehot_[a-z,_]*')
-
 if legacy_opset_pre_ver(7):
   backend_test.exclude(r'[a-z,_]*Upsample[a-z,_]*')
 


### PR DESCRIPTION
cast "indices" base on auto-cast option instead of always cast to int64

Signed-off-by: Winnie Tsang <wtsang@us.ibm.com>