### PR TITLE
Fix Slice version 1 to support model zoo models

### DIFF
--- a/onnx_tf/handlers/backend/slice.py
+++ b/onnx_tf/handlers/backend/slice.py
@@ -14,7 +14,8 @@ class Slice(BackendHandler):
     tensor_dict = kwargs["tensor_dict"]
     x = tensor_dict[node.inputs[0]]
 
-    full_sizes = tf.shape(x)
+    # Shape output as int64 since the spec implicitly allows int64
+    full_sizes = tf.shape(x, out_type=tf.int64)
 
     starts = node.attrs.get("starts")
     ends = node.attrs.get("ends")


### PR DESCRIPTION
Fix Slice version 1 to support model zoo models:
age_gender, version-RFB-320.onnx
age_gender, version-RFB-640.onnx

Signed-off-by: Chin Huang <chhuang@us.ibm.com>