### PR TITLE
Fixed a typo in converter.py

### DIFF
--- a/onnx_tf/converter.py
+++ b/onnx_tf/converter.py
@@ -133,4 +133,4 @@ def convert(infile, outdir, **kwargs):
   onnx_model = onnx.load(infile)
   tf_rep = backend.prepare(onnx_model, **kwargs)
   tf_rep.export_graph(outdir)
-  common.logger.info("Converting completes successfully.")
+  common.logger.info("Converting completed successfully.")


### PR DESCRIPTION
Fixed a typo in converter.py
"Converting completes successfully." -> "Converting completed successfully."