### PR TITLE
Add new data types support for Pad

### DIFF
--- a/onnx_tf/handlers/backend/pad.py
+++ b/onnx_tf/handlers/backend/pad.py
@@ -89,3 +89,7 @@ class Pad(BackendHandler):
   @classmethod
   def version_11(cls, node, **kwargs):
     return cls._common(node, **kwargs)
+
+  @classmethod
+  def version_13(cls, node, **kwargs):
+    return cls._common(node, **kwargs)

--- a/onnx_tf/opset_version.py
+++ b/onnx_tf/opset_version.py
@@ -108,7 +108,7 @@ backend_opset_version = {
     'OneHotEncoder': [],
     'Or': [1, 7],
     'PRelu': [1, 6, 7, 9],
-    'Pad': [1, 2, 11],
+    'Pad': [1, 2, 11, 13],
     'Pow': [1, 7, 12, 13],
     'QLinearConv': [10],
     'QLinearMatMul': [10],


### PR DESCRIPTION
Add new data types support for Pad, which gets
string, bool, and bfloat16. Also add a test case
for string type.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>