### PR TITLE
Support train onnx model with tensorflow

### DIFF
--- a/example/train_onnx_model.py
+++ b/example/train_onnx_model.py
@@ -1,0 +1,179 @@
+import os
+import time
+import onnx
+import logging
+import numpy as np
+
+import tensorflow as tf
+from _ast import Break
+tf_compat = tf.compat.v1
+import tensorflow_datasets as tfds
+
+import onnx_tf
+from onnx_tf.backend import prepare
+
+batch_size = 32
+epochs=4
+
+saved_model_path = './saved_model/'
+onnx_model_file = './onnx_model/model.onnx'
+trained_onnx_model = './onnx_model/trained.onnx'
+onnx_model_path = os.path.dirname(onnx_model_file)
+
+def get_dataset():
+    dataset = tf.keras.datasets.cifar10
+    
+    (x_train, y_train), (x_test, y_test) = dataset.load_data()
+    x_train, x_test = x_train / 255.0, x_test / 255.0
+    
+    train_ds = tf.data.Dataset.from_tensor_slices(
+        (x_train, y_train)).shuffle(10000).batch(batch_size, drop_remainder=True)
+    test_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test)).batch(batch_size, drop_remainder=True)
+    return train_ds, test_ds
+    
+def save_trained_onnx(tensor_dict, onnx_model, sess):
+    # Collect retrained parameters.
+    retrained_params = {}
+    for name, tensor in tensor_dict.items():
+        if isinstance(tensor, tf.Variable):
+            retrained_params[name] = sess.run(tensor)
+
+    # Update onnx model using new parameters:
+    from onnx import mapping
+    for tensor in onnx_model.graph.initializer:
+        if tensor.name in retrained_params:
+            print("Updating {}.".format(tensor.name))
+            assert tensor.HasField("raw_data")
+            tensor.raw_data = retrained_params[tensor.name].tobytes()
+    
+    onnx.save(onnx_model, trained_onnx_model)
+    
+def train_tf_model():
+    import tensorflow as tf
+    from tensorflow.keras import datasets, layers, models
+    model = models.Sequential()
+    model.add(layers.Conv2D(32, (3, 3), activation='relu', input_shape=(32, 32, 3)))
+    model.add(layers.MaxPooling2D((2, 2)))
+    model.add(layers.Conv2D(64, (3, 3), activation='relu'))
+    model.add(layers.MaxPooling2D((2, 2)))
+    model.add(layers.Conv2D(64, (3, 3), activation='relu'))
+    
+    model.add(layers.Flatten())
+    model.add(layers.Dense(64, activation='relu'))
+    model.add(layers.Dense(10))
+        
+    if not os.path.exists(saved_model_path):
+        os.mkdir(saved_model_path)
+    model.save(saved_model_path)
+    model.summary()
+    print("tf saved model: {}".format(saved_model_path))
+    
+    '''
+    (train_images, train_labels), (test_images, test_labels) = datasets.cifar10.load_data()
+    train_images, test_images = train_images / 255.0, test_images / 255.0
+    
+    model.compile(optimizer='adam',
+              loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+              metrics=['accuracy'])
+
+    history = model.fit(train_images, train_labels, epochs=4, 
+                    validation_data=(test_images, test_labels))
+    test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)
+    model.save(saved_model_path)
+    '''
+    
+def convert_tf2onnx():
+    if not os.path.exists(onnx_model_path):
+        os.mkdir(onnx_model_path)
+    os.system('python -m tf2onnx.convert --saved-model {} --output {}'.format(saved_model_path, onnx_model_file))
+    print('onnx model: {}'.format(onnx_model_file))
+    
+def train_onnx_model():
+    onnx_model = onnx.load(onnx_model_file)
+    tf_rep = prepare(onnx_model, training_mode=True, logging_level=logging.ERROR)
+    training_flag_placeholder = tf_rep.tensor_dict[onnx_tf.backend.training_flag_name]
+    input_name = onnx_model.graph.input[0].name
+    output_name = onnx_model.graph.output[0].name
+    
+    with tf_rep.graph.as_default():
+        with tf_compat.Session() as sess:
+            y_truth = tf_compat.placeholder(tf.int64, [None], name='y-input')
+            tf_rep.tensor_dict["y_truth"] = y_truth
+            loss_op = tf.reduce_mean(
+                tf_compat.losses.sparse_softmax_cross_entropy(
+                    labels=tf_rep.tensor_dict['y_truth'],
+                    logits=tf_rep.tensor_dict[output_name]))
+            opt_op = tf_compat.train.AdamOptimizer().minimize(loss_op)
+            eval_op = tf.reduce_mean(input_tensor=tf.cast(
+                tf.equal(tf.argmax(input=tf_rep.tensor_dict[output_name], axis=1), tf_rep.tensor_dict['y_truth']), tf.float32))
+            
+            train_data, test_data = get_dataset()
+            sess.run(tf_compat.global_variables_initializer())
+            print("==> Train the model..")
+            
+            for epoch in range(1, epochs+1):
+                step = 1
+                next_batch=tf.compat.v1.data.make_one_shot_iterator(train_data).get_next()
+                while True:
+                    try:
+                        time1 = time.time()
+                        next_batch_value = sess.run(next_batch)
+                        time2 = time.time()
+                        feed_dict = {
+                            #tf_rep.tensor_dict[input_name]: next_batch_value[0].transpose((0, 3, 1, 2)),#for pytorch model
+                            tf_rep.tensor_dict[input_name]: next_batch_value[0],
+                            tf_rep.tensor_dict['y_truth']: next_batch_value[1].flatten()
+                        }
+                        feed_dict[training_flag_placeholder] = True
+                        loss, accuracy, _ = sess.run([loss_op, eval_op, opt_op], feed_dict=feed_dict)
+                        time3 = time.time()
+                        if (step % 100) == 0:
+                            print('Epoch {}, train step {}, loss:{}, accuracy:{}'.format(epoch, step, loss, accuracy))
+                            #print('Epoch {}, Train Step {}, Loss:{:.2f}, Use {}s'.format(epoch, step, loss, time3-time1))
+                        step += 1
+                    except tf.errors.OutOfRangeError:
+                        step = 1
+                        next_batch=tf.compat.v1.data.make_one_shot_iterator(test_data).get_next()
+                        while True:
+                            try:
+                                next_batch_value = sess.run(next_batch)
+                                feed_dict = {
+                                    #tf_rep.tensor_dict[input_name]: next_batch_value[0].transpose((0, 3, 1, 2)),#for pytorch model
+                                    tf_rep.tensor_dict[input_name]: next_batch_value[0],
+                                    tf_rep.tensor_dict['y_truth']: next_batch_value[1].flatten()
+                                }
+                                feed_dict[training_flag_placeholder] = False
+                                loss, accuracy, _ = sess.run([loss_op, eval_op, opt_op], feed_dict=feed_dict)
+                                if (step % 100) == 0:
+                                    print('Epoch {}, test* step {}, loss:{}, accuracy:{}'.format(epoch, step, loss, accuracy))
+                                step += 1
+                            except tf.errors.OutOfRangeError:
+                                break
+                        break
+            save_trained_onnx(tf_rep.tensor_dict, onnx_model, sess)
+    
+def run_trained_onnx_model():
+    onnx_model = onnx.load(trained_onnx_model)
+    tf_rep = prepare(onnx_model,logging_level=logging.ERROR)
+    input_name = tf_rep.inputs[0]
+    output_name = tf_rep.outputs[0]
+    train_data, test_data = get_dataset()
+    
+    for img, label in test_data:
+        input = img.numpy().astype('float32')
+        gt = label.numpy()
+        break
+    
+    output = tf_rep.run({input_name:input})
+    
+    pred = np.argmax(output[0], axis=1).tolist()
+    print("labels:{}".format(gt.flatten().tolist()))
+    print("  pred:{}".format(pred))
+    
+if __name__ == "__main__":
+    train_tf_model()
+    convert_tf2onnx()
+    train_onnx_model()
+    run_trained_onnx_model()
+
+

--- a/example/train_onnx_model.py
+++ b/example/train_onnx_model.py
@@ -1,5 +1,4 @@
 import os
-import time
 import onnx
 import logging
 import numpy as np
@@ -7,7 +6,7 @@ import numpy as np
 import tensorflow as tf
 tf_compat = tf.compat.v1
 from tensorflow.keras import datasets, layers, models
-from onnx_tf.backend import prepare, training_flag_name
+import onnx_tf
 
 batch_size = 32
 epochs = 4
@@ -19,7 +18,7 @@ onnx_model_path = os.path.dirname(onnx_model_file)
 
 
 def get_dataset():
-  dataset = tf.keras.datasets.cifar10
+  dataset = datasets.cifar10
 
   (x_train, y_train), (x_test, y_test) = dataset.load_data()
   x_train, x_test = x_train / 255.0, x_test / 255.0
@@ -92,8 +91,11 @@ def convert_tf2onnx():
 
 def train_onnx_model():
   onnx_model = onnx.load(onnx_model_file)
-  tf_rep = prepare(onnx_model, training_mode=True, logging_level=logging.ERROR)
-  training_flag_placeholder = tf_rep.tensor_dict[training_flag_name]
+  tf_rep = onnx_tf.backend.prepare(onnx_model,
+                                   training_mode=True,
+                                   logging_level=logging.ERROR)
+  training_flag_placeholder = tf_rep.tensor_dict[
+      onnx_tf.backend.training_flag_name]
   input_name = onnx_model.graph.input[0].name
   output_name = onnx_model.graph.output[0].name
 
@@ -164,7 +166,7 @@ def train_onnx_model():
 
 def run_trained_onnx_model():
   onnx_model = onnx.load(trained_onnx_model)
-  tf_rep = prepare(onnx_model, logging_level=logging.ERROR)
+  tf_rep = onnx_tf.backend.prepare(onnx_model, logging_level=logging.ERROR)
   input_name = tf_rep.inputs[0]
   train_data, test_data = get_dataset()
 

--- a/example/train_onnx_model.py
+++ b/example/train_onnx_model.py
@@ -38,7 +38,6 @@ def save_trained_onnx(tensor_dict, onnx_model, sess):
       retrained_params[name] = sess.run(tensor)
 
   # Update onnx model using new parameters:
-  from onnx import mapping
   for tensor in onnx_model.graph.initializer:
     if tensor.name in retrained_params:
       print("Updating {}.".format(tensor.name))

--- a/example/train_onnx_model.py
+++ b/example/train_onnx_model.py
@@ -9,19 +9,26 @@ from tensorflow.keras import datasets, layers, models
 import onnx_tf
 
 batch_size = 32
-epochs = 4
+epochs = 2
 
 saved_model_path = './saved_model/'
 onnx_model_file = './onnx_model/model.onnx'
 trained_onnx_model = './onnx_model/trained.onnx'
 onnx_model_path = os.path.dirname(onnx_model_file)
+use_dataset = 'mnist'  # mnist or cifar10
 
 
 def get_dataset():
-  dataset = datasets.cifar10
+  if use_dataset == 'mnist':
+    dataset = datasets.mnist
+  else:
+    dataset = datasets.cifar10
 
   (x_train, y_train), (x_test, y_test) = dataset.load_data()
   x_train, x_test = x_train / 255.0, x_test / 255.0
+  if use_dataset == 'mnist':
+    x_train = x_train[..., tf.newaxis]
+    x_test = x_test[..., tf.newaxis]
 
   train_ds = tf.data.Dataset.from_tensor_slices(
       (x_train, y_train)).shuffle(10000).batch(batch_size, drop_remainder=True)
@@ -48,9 +55,13 @@ def save_trained_onnx(tensor_dict, onnx_model, sess):
 
 
 def train_tf_model():
+  if use_dataset == 'mnist':
+    input_shape = (28, 28, 1)
+  else:
+    input_shape = (32, 32, 3)
   model = models.Sequential()
   model.add(
-      layers.Conv2D(32, (3, 3), activation='relu', input_shape=(32, 32, 3)))
+      layers.Conv2D(32, (3, 3), activation='relu', input_shape=input_shape))
   model.add(layers.MaxPooling2D((2, 2)))
   model.add(layers.Conv2D(64, (3, 3), activation='relu'))
   model.add(layers.MaxPooling2D((2, 2)))

--- a/example/train_onnx_model.py
+++ b/example/train_onnx_model.py
@@ -13,62 +13,66 @@ import onnx_tf
 from onnx_tf.backend import prepare
 
 batch_size = 32
-epochs=4
+epochs = 4
 
 saved_model_path = './saved_model/'
 onnx_model_file = './onnx_model/model.onnx'
 trained_onnx_model = './onnx_model/trained.onnx'
 onnx_model_path = os.path.dirname(onnx_model_file)
 
-def get_dataset():
-    dataset = tf.keras.datasets.cifar10
-    
-    (x_train, y_train), (x_test, y_test) = dataset.load_data()
-    x_train, x_test = x_train / 255.0, x_test / 255.0
-    
-    train_ds = tf.data.Dataset.from_tensor_slices(
-        (x_train, y_train)).shuffle(10000).batch(batch_size, drop_remainder=True)
-    test_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test)).batch(batch_size, drop_remainder=True)
-    return train_ds, test_ds
-    
-def save_trained_onnx(tensor_dict, onnx_model, sess):
-    # Collect retrained parameters.
-    retrained_params = {}
-    for name, tensor in tensor_dict.items():
-        if isinstance(tensor, tf.Variable):
-            retrained_params[name] = sess.run(tensor)
 
-    # Update onnx model using new parameters:
-    from onnx import mapping
-    for tensor in onnx_model.graph.initializer:
-        if tensor.name in retrained_params:
-            print("Updating {}.".format(tensor.name))
-            assert tensor.HasField("raw_data")
-            tensor.raw_data = retrained_params[tensor.name].tobytes()
-    
-    onnx.save(onnx_model, trained_onnx_model)
-    
+def get_dataset():
+  dataset = tf.keras.datasets.cifar10
+
+  (x_train, y_train), (x_test, y_test) = dataset.load_data()
+  x_train, x_test = x_train / 255.0, x_test / 255.0
+
+  train_ds = tf.data.Dataset.from_tensor_slices(
+      (x_train, y_train)).shuffle(10000).batch(batch_size, drop_remainder=True)
+  test_ds = tf.data.Dataset.from_tensor_slices(
+      (x_test, y_test)).batch(batch_size, drop_remainder=True)
+  return train_ds, test_ds
+
+
+def save_trained_onnx(tensor_dict, onnx_model, sess):
+  # Collect retrained parameters.
+  retrained_params = {}
+  for name, tensor in tensor_dict.items():
+    if isinstance(tensor, tf.Variable):
+      retrained_params[name] = sess.run(tensor)
+
+  # Update onnx model using new parameters:
+  from onnx import mapping
+  for tensor in onnx_model.graph.initializer:
+    if tensor.name in retrained_params:
+      print("Updating {}.".format(tensor.name))
+      assert tensor.HasField("raw_data")
+      tensor.raw_data = retrained_params[tensor.name].tobytes()
+
+  onnx.save(onnx_model, trained_onnx_model)
+
+
 def train_tf_model():
-    import tensorflow as tf
-    from tensorflow.keras import datasets, layers, models
-    model = models.Sequential()
-    model.add(layers.Conv2D(32, (3, 3), activation='relu', input_shape=(32, 32, 3)))
-    model.add(layers.MaxPooling2D((2, 2)))
-    model.add(layers.Conv2D(64, (3, 3), activation='relu'))
-    model.add(layers.MaxPooling2D((2, 2)))
-    model.add(layers.Conv2D(64, (3, 3), activation='relu'))
-    
-    model.add(layers.Flatten())
-    model.add(layers.Dense(64, activation='relu'))
-    model.add(layers.Dense(10))
-        
-    if not os.path.exists(saved_model_path):
-        os.mkdir(saved_model_path)
-    model.save(saved_model_path)
-    model.summary()
-    print("tf saved model: {}".format(saved_model_path))
-    
-    '''
+  import tensorflow as tf
+  from tensorflow.keras import datasets, layers, models
+  model = models.Sequential()
+  model.add(
+      layers.Conv2D(32, (3, 3), activation='relu', input_shape=(32, 32, 3)))
+  model.add(layers.MaxPooling2D((2, 2)))
+  model.add(layers.Conv2D(64, (3, 3), activation='relu'))
+  model.add(layers.MaxPooling2D((2, 2)))
+  model.add(layers.Conv2D(64, (3, 3), activation='relu'))
+
+  model.add(layers.Flatten())
+  model.add(layers.Dense(64, activation='relu'))
+  model.add(layers.Dense(10))
+
+  if not os.path.exists(saved_model_path):
+    os.mkdir(saved_model_path)
+  model.save(saved_model_path)
+  model.summary()
+  print("tf saved model: {}".format(saved_model_path))
+  '''
     (train_images, train_labels), (test_images, test_labels) = datasets.cifar10.load_data()
     train_images, test_images = train_images / 255.0, test_images / 255.0
     
@@ -81,99 +85,114 @@ def train_tf_model():
     test_loss, test_acc = model.evaluate(test_images,  test_labels, verbose=2)
     model.save(saved_model_path)
     '''
-    
+
+
 def convert_tf2onnx():
-    if not os.path.exists(onnx_model_path):
-        os.mkdir(onnx_model_path)
-    os.system('python -m tf2onnx.convert --saved-model {} --output {}'.format(saved_model_path, onnx_model_file))
-    print('onnx model: {}'.format(onnx_model_file))
-    
+  if not os.path.exists(onnx_model_path):
+    os.mkdir(onnx_model_path)
+  os.system('python -m tf2onnx.convert --saved-model {} --output {}'.format(
+      saved_model_path, onnx_model_file))
+  print('onnx model: {}'.format(onnx_model_file))
+
+
 def train_onnx_model():
-    onnx_model = onnx.load(onnx_model_file)
-    tf_rep = prepare(onnx_model, training_mode=True, logging_level=logging.ERROR)
-    training_flag_placeholder = tf_rep.tensor_dict[onnx_tf.backend.training_flag_name]
-    input_name = onnx_model.graph.input[0].name
-    output_name = onnx_model.graph.output[0].name
-    
-    with tf_rep.graph.as_default():
-        with tf_compat.Session() as sess:
-            y_truth = tf_compat.placeholder(tf.int64, [None], name='y-input')
-            tf_rep.tensor_dict["y_truth"] = y_truth
-            loss_op = tf.reduce_mean(
-                tf_compat.losses.sparse_softmax_cross_entropy(
-                    labels=tf_rep.tensor_dict['y_truth'],
-                    logits=tf_rep.tensor_dict[output_name]))
-            opt_op = tf_compat.train.AdamOptimizer().minimize(loss_op)
-            eval_op = tf.reduce_mean(input_tensor=tf.cast(
-                tf.equal(tf.argmax(input=tf_rep.tensor_dict[output_name], axis=1), tf_rep.tensor_dict['y_truth']), tf.float32))
-            
-            train_data, test_data = get_dataset()
-            sess.run(tf_compat.global_variables_initializer())
-            print("==> Train the model..")
-            
-            for epoch in range(1, epochs+1):
-                step = 1
-                next_batch=tf.compat.v1.data.make_one_shot_iterator(train_data).get_next()
-                while True:
-                    try:
-                        time1 = time.time()
-                        next_batch_value = sess.run(next_batch)
-                        time2 = time.time()
-                        feed_dict = {
-                            #tf_rep.tensor_dict[input_name]: next_batch_value[0].transpose((0, 3, 1, 2)),#for pytorch model
-                            tf_rep.tensor_dict[input_name]: next_batch_value[0],
-                            tf_rep.tensor_dict['y_truth']: next_batch_value[1].flatten()
-                        }
-                        feed_dict[training_flag_placeholder] = True
-                        loss, accuracy, _ = sess.run([loss_op, eval_op, opt_op], feed_dict=feed_dict)
-                        time3 = time.time()
-                        if (step % 100) == 0:
-                            print('Epoch {}, train step {}, loss:{}, accuracy:{}'.format(epoch, step, loss, accuracy))
-                            #print('Epoch {}, Train Step {}, Loss:{:.2f}, Use {}s'.format(epoch, step, loss, time3-time1))
-                        step += 1
-                    except tf.errors.OutOfRangeError:
-                        step = 1
-                        next_batch=tf.compat.v1.data.make_one_shot_iterator(test_data).get_next()
-                        while True:
-                            try:
-                                next_batch_value = sess.run(next_batch)
-                                feed_dict = {
-                                    #tf_rep.tensor_dict[input_name]: next_batch_value[0].transpose((0, 3, 1, 2)),#for pytorch model
-                                    tf_rep.tensor_dict[input_name]: next_batch_value[0],
-                                    tf_rep.tensor_dict['y_truth']: next_batch_value[1].flatten()
-                                }
-                                feed_dict[training_flag_placeholder] = False
-                                loss, accuracy, _ = sess.run([loss_op, eval_op, opt_op], feed_dict=feed_dict)
-                                if (step % 100) == 0:
-                                    print('Epoch {}, test* step {}, loss:{}, accuracy:{}'.format(epoch, step, loss, accuracy))
-                                step += 1
-                            except tf.errors.OutOfRangeError:
-                                break
-                        break
-            save_trained_onnx(tf_rep.tensor_dict, onnx_model, sess)
-    
+  onnx_model = onnx.load(onnx_model_file)
+  tf_rep = prepare(onnx_model, training_mode=True, logging_level=logging.ERROR)
+  training_flag_placeholder = tf_rep.tensor_dict[
+      onnx_tf.backend.training_flag_name]
+  input_name = onnx_model.graph.input[0].name
+  output_name = onnx_model.graph.output[0].name
+
+  with tf_rep.graph.as_default():
+    with tf_compat.Session() as sess:
+      y_truth = tf_compat.placeholder(tf.int64, [None], name='y-input')
+      tf_rep.tensor_dict["y_truth"] = y_truth
+      loss_op = tf.reduce_mean(
+          tf_compat.losses.sparse_softmax_cross_entropy(
+              labels=tf_rep.tensor_dict['y_truth'],
+              logits=tf_rep.tensor_dict[output_name]))
+      opt_op = tf_compat.train.AdamOptimizer().minimize(loss_op)
+      eval_op = tf.reduce_mean(input_tensor=tf.cast(
+          tf.equal(tf.argmax(input=tf_rep.tensor_dict[output_name], axis=1),
+                   tf_rep.tensor_dict['y_truth']), tf.float32))
+
+      train_data, test_data = get_dataset()
+      sess.run(tf_compat.global_variables_initializer())
+      print("==> Train the model..")
+
+      for epoch in range(1, epochs + 1):
+        step = 1
+        next_batch = tf.compat.v1.data.make_one_shot_iterator(
+            train_data).get_next()
+        while True:
+          try:
+            time1 = time.time()
+            next_batch_value = sess.run(next_batch)
+            time2 = time.time()
+            feed_dict = {
+                #tf_rep.tensor_dict[input_name]: next_batch_value[0].transpose((0, 3, 1, 2)),#for pytorch model
+                tf_rep.tensor_dict[input_name]:
+                    next_batch_value[0],
+                tf_rep.tensor_dict['y_truth']:
+                    next_batch_value[1].flatten()
+            }
+            feed_dict[training_flag_placeholder] = True
+            loss, accuracy, _ = sess.run([loss_op, eval_op, opt_op],
+                                         feed_dict=feed_dict)
+            time3 = time.time()
+            if (step % 100) == 0:
+              print('Epoch {}, train step {}, loss:{}, accuracy:{}'.format(
+                  epoch, step, loss, accuracy))
+              #print('Epoch {}, Train Step {}, Loss:{:.2f}, Use {}s'.format(epoch, step, loss, time3-time1))
+            step += 1
+          except tf.errors.OutOfRangeError:
+            step = 1
+            next_batch = tf.compat.v1.data.make_one_shot_iterator(
+                test_data).get_next()
+            while True:
+              try:
+                next_batch_value = sess.run(next_batch)
+                feed_dict = {
+                    #tf_rep.tensor_dict[input_name]: next_batch_value[0].transpose((0, 3, 1, 2)),#for pytorch model
+                    tf_rep.tensor_dict[input_name]:
+                        next_batch_value[0],
+                    tf_rep.tensor_dict['y_truth']:
+                        next_batch_value[1].flatten()
+                }
+                feed_dict[training_flag_placeholder] = False
+                loss, accuracy, _ = sess.run([loss_op, eval_op, opt_op],
+                                             feed_dict=feed_dict)
+                if (step % 100) == 0:
+                  print('Epoch {}, test* step {}, loss:{}, accuracy:{}'.format(
+                      epoch, step, loss, accuracy))
+                step += 1
+              except tf.errors.OutOfRangeError:
+                break
+            break
+      save_trained_onnx(tf_rep.tensor_dict, onnx_model, sess)
+
+
 def run_trained_onnx_model():
-    onnx_model = onnx.load(trained_onnx_model)
-    tf_rep = prepare(onnx_model,logging_level=logging.ERROR)
-    input_name = tf_rep.inputs[0]
-    output_name = tf_rep.outputs[0]
-    train_data, test_data = get_dataset()
-    
-    for img, label in test_data:
-        input = img.numpy().astype('float32')
-        gt = label.numpy()
-        break
-    
-    output = tf_rep.run({input_name:input})
-    
-    pred = np.argmax(output[0], axis=1).tolist()
-    print("labels:{}".format(gt.flatten().tolist()))
-    print("  pred:{}".format(pred))
-    
+  onnx_model = onnx.load(trained_onnx_model)
+  tf_rep = prepare(onnx_model, logging_level=logging.ERROR)
+  input_name = tf_rep.inputs[0]
+  output_name = tf_rep.outputs[0]
+  train_data, test_data = get_dataset()
+
+  for img, label in test_data:
+    input = img.numpy().astype('float32')
+    gt = label.numpy()
+    break
+
+  output = tf_rep.run({input_name: input})
+
+  pred = np.argmax(output[0], axis=1).tolist()
+  print("labels:{}".format(gt.flatten().tolist()))
+  print("  pred:{}".format(pred))
+
+
 if __name__ == "__main__":
-    train_tf_model()
-    convert_tf2onnx()
-    train_onnx_model()
-    run_trained_onnx_model()
-
-
+  train_tf_model()
+  convert_tf2onnx()
+  train_onnx_model()
+  run_trained_onnx_model()

--- a/example/train_onnx_model.py
+++ b/example/train_onnx_model.py
@@ -17,6 +17,7 @@ onnx_model_file = './onnx_model/model.onnx'
 trained_onnx_model = './onnx_model/trained.onnx'
 onnx_model_path = os.path.dirname(onnx_model_file)
 
+
 def get_dataset():
   dataset = tf.keras.datasets.cifar10
 
@@ -92,8 +93,7 @@ def convert_tf2onnx():
 def train_onnx_model():
   onnx_model = onnx.load(onnx_model_file)
   tf_rep = prepare(onnx_model, training_mode=True, logging_level=logging.ERROR)
-  training_flag_placeholder = tf_rep.tensor_dict[
-      onnx_tf.backend.training_flag_name]
+  training_flag_placeholder = tf_rep.tensor_dict[training_flag_name]
   input_name = onnx_model.graph.input[0].name
   output_name = onnx_model.graph.output[0].name
 

--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -19,6 +19,7 @@ from onnx.backend.base import namedtupledict
 from onnx.backend.test.runner import BackendIsNotSupposedToImplementIt
 from onnx.helper import make_opsetid
 import tensorflow as tf
+import numpy as np
 
 from onnx_tf.backend_rep import TensorflowRep
 from onnx_tf.common import data_type
@@ -29,6 +30,7 @@ from onnx_tf.pb_wrapper import OnnxNode
 from onnx_tf.backend_tf_module import BackendTFModule, TFModule
 import onnx_tf.common as common
 
+training_flag_name = "_onnx_tf_internal_is_training"
 
 class TensorflowBackend(Backend):
   """ Tensorflow Backend for ONNX
@@ -107,6 +109,8 @@ class TensorflowBackend(Backend):
     # User provided input tensors, in the case the model inputs have unknown shapes
     input_tensor_dict = kwargs[
         'input_tensor_dict'] if 'input_tensor_dict' in kwargs else dict()
+    training_mode = kwargs[
+        'training_mode'] if 'training_mode' in kwargs else dict()
 
     handlers = cls._get_handlers(opset)
 
@@ -123,31 +127,47 @@ class TensorflowBackend(Backend):
 
     module = BackendTFModule(handlers, opset, strict, graph_def, cls)
     signatures = dict()
-    for value_info in graph_def.input:
-      if value_info.name in initialized:
-        continue
-      shape = list(
-          d.dim_value if (d.dim_value > 0 and d.dim_param == "") else None
-          for d in value_info.type.tensor_type.shape.dim)
-      value_info_name = value_info.name.replace(
-          ":", "_tf_") + "_" + get_unique_suffix(
-          ) if ":" in value_info.name else value_info.name
-
-      tf_spec = tf.TensorSpec(
-          shape, data_type.onnx2tf(value_info.type.tensor_type.elem_type),
-          value_info_name)
-      signatures[value_info.name] = tf_spec
-
-      if gen_tensor_dict:
-        x = tf.constant(
-            0,
-            dtype=data_type.onnx2tf(value_info.type.tensor_type.elem_type),
-            name=value_info_name,
-            shape=shape
-        ) if value_info.name not in input_tensor_dict else input_tensor_dict[
-            value_info.name]
-        input_dict[value_info.name] = x
-
+    tf_rep_graph = tf.Graph()
+    with tf_rep_graph.as_default():
+        for value_info in graph_def.input:
+          if value_info.name in initialized:
+            continue
+          shape = list(
+              d.dim_value if (d.dim_value > 0 and d.dim_param == "") else None
+              for d in value_info.type.tensor_type.shape.dim)
+          value_info_name = value_info.name.replace(
+              ":", "_tf_") + "_" + get_unique_suffix(
+              ) if ":" in value_info.name else value_info.name
+    
+          tf_spec = tf.TensorSpec(
+              shape, data_type.onnx2tf(value_info.type.tensor_type.elem_type),
+              value_info_name)
+          signatures[value_info.name] = tf_spec
+    
+          if gen_tensor_dict or training_mode:
+            x = tf.compat.v1.placeholder(data_type.onnx2tf(
+                value_info.type.tensor_type.elem_type),
+                                     name=value_info_name,
+                                     shape=shape
+                ) if value_info.name not in input_tensor_dict else input_tensor_dict[
+                value_info.name]
+            input_dict[value_info.name] = x
+        
+        if gen_tensor_dict or training_mode:
+            input_dict_items = cls._onnx_initializer_to_input_dict_items(graph_def.initializer)
+            tensor_dict = dict(input_dict)
+            tensor_dict.update(input_dict_items)
+            tensor_dict[training_flag_name] = tf.compat.v1.placeholder_with_default(False,shape=[])
+            for node in graph_def.node:
+                onnx_node = OnnxNode(node)
+                output_ops = cls._onnx_node_to_tensorflow_op(onnx_node,
+                                                     tensor_dict,
+                                                     handlers,
+                                                     opset=opset,
+                                                     strict=strict)
+                curr_node_output_map = dict(zip(onnx_node.outputs, output_ops))
+                tensor_dict.update(curr_node_output_map)
+        
     tf_rep = TensorflowRep()
     tf_rep.inputs = [
         value_info.name
@@ -158,8 +178,10 @@ class TensorflowBackend(Backend):
     module.outputs = tf_rep.outputs
     tf_rep.tf_module = module
     tf_rep.signatures = signatures
-    tf_rep.tensor_dict = module.gen_tensor_dict(
-        input_dict) if gen_tensor_dict else None
+    if gen_tensor_dict or training_mode:
+        tf_rep.tensor_dict = tensor_dict
+    if training_mode:
+        tf_rep.graph = tf_rep_graph
     tf_rep.onnx_op_list = cls._get_onnx_op_list(graph_def)
     return tf_rep
 
@@ -254,12 +276,13 @@ class TensorflowBackend(Backend):
       return name.replace(
           ":", "_tf_") + "_" + get_unique_suffix() if ":" in name else name
 
-    return [(init.name,
-             tf.constant(tensor2list(init),
-                         shape=init.dims,
-                         dtype=data_type.onnx2tf(init.data_type),
-                         name=validate_initializer_name(init.name)))
-            for init in initializer]
+    tensor_dict = [(init.name,
+                    tf.Variable(np.array(tensor2list(init)).reshape(init.dims),
+                                shape=init.dims,
+                                dtype=data_type.onnx2tf(init.data_type),
+                                name=validate_initializer_name(init.name)))
+                   for init in initializer]
+    return tensor_dict
 
   @classmethod
   def _onnx_node_to_tensorflow_op(cls,

--- a/onnx_tf/backend.py
+++ b/onnx_tf/backend.py
@@ -111,7 +111,7 @@ class TensorflowBackend(Backend):
     input_tensor_dict = kwargs[
         'input_tensor_dict'] if 'input_tensor_dict' in kwargs else dict()
     training_mode = kwargs[
-        'training_mode'] if 'training_mode' in kwargs else dict()
+        'training_mode'] if 'training_mode' in kwargs else False
 
     handlers = cls._get_handlers(opset)
 

--- a/onnx_tf/handlers/backend/broadcast_mixin.py
+++ b/onnx_tf/handlers/backend/broadcast_mixin.py
@@ -1,20 +1,20 @@
 import numpy as np
 import tensorflow as tf
 
+def is_tensor_or_var(obj):
+    return isinstance(obj, tf.Tensor) or isinstance(obj, tf.Variable)
 
 class BroadcastMixin(object):
 
   @classmethod
   def explicit_broadcast(cls, inputs, axis=None, tensor_dict=None):
-    x = inputs[0] if isinstance(inputs[0],
-                                tf.Tensor) else tensor_dict[inputs[0]]
-    y = inputs[1] if isinstance(inputs[1],
-                                tf.Tensor) else tensor_dict[inputs[1]]
+    x = inputs[0] if is_tensor_or_var(inputs[0]) else tensor_dict[inputs[0]]
+    y = inputs[1] if is_tensor_or_var(inputs[1]) else tensor_dict[inputs[1]]
 
     if np.prod(y.shape) == 1:
       return y
 
-    if not isinstance(x, tf.Tensor) or not isinstance(y, tf.Tensor):
+    if not is_tensor_or_var(x) or not is_tensor_or_var(y):
       raise ValueError("Targets for explicit broadcasting need to be Tensor.")
 
     if axis is None:

--- a/onnx_tf/handlers/backend/broadcast_mixin.py
+++ b/onnx_tf/handlers/backend/broadcast_mixin.py
@@ -1,8 +1,10 @@
 import numpy as np
 import tensorflow as tf
 
+
 def is_tensor_or_var(obj):
-    return isinstance(obj, tf.Tensor) or isinstance(obj, tf.Variable)
+  return isinstance(obj, tf.Tensor) or isinstance(obj, tf.Variable)
+
 
 class BroadcastMixin(object):
 


### PR DESCRIPTION
1. Update backend.prepare() to generate tf_rep for model training: generate tensor_dict and graph only in training mode. 
2. Add an example to train a onnx model : example/train_onnx_model.py
3. Batchnomalization OP for training model is not supported so far. 