### PR TITLE
Fix Div to return the original data types

### DIFF
--- a/onnx_tf/handlers/backend/div.py
+++ b/onnx_tf/handlers/backend/div.py
@@ -11,6 +11,17 @@ from .math_mixin import ArithmeticMixin
 class Div(ArithmeticMixin, BackendHandler):
 
   @classmethod
+  def _common(cls, node, **kwargs):
+    # Tensorflow automatically casts inputs to a float type for integers
+    # in tf.math.truediv and returns output in floating point. We need to
+    # case the output back to the original data type when needed.
+    dtype = kwargs['tensor_dict'][node.inputs[0]].dtype
+    result = [cls.make_tensor_from_onnx_node(node, **kwargs)] if dtype in [
+        tf.float16, tf.float32, tf.float64, tf.bfloat16
+    ] else [tf.cast(cls.make_tensor_from_onnx_node(node, **kwargs), dtype)]
+    return result
+
+  @classmethod
   def version_1(cls, node, **kwargs):
     return cls.limited_broadcast(node, **kwargs)
 
@@ -20,8 +31,8 @@ class Div(ArithmeticMixin, BackendHandler):
 
   @classmethod
   def version_7(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    return cls._common(node, **kwargs)
 
   @classmethod
   def version_13(cls, node, **kwargs):
-    return [cls.make_tensor_from_onnx_node(node, **kwargs)]
+    return cls._common(node, **kwargs)


### PR DESCRIPTION
Fix Div to return the original data types when the inputs are
integers. In such case, Tensorflow automatically casts inputs to
a float type and returns in floating point in tf.math.truediv. So
we need to handle these integral data types propertly.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>