### PR TITLE
Fix InstanceNormalization unknown channel size issue

### DIFF
--- a/onnx_tf/handlers/backend/instance_normalization.py
+++ b/onnx_tf/handlers/backend/instance_normalization.py
@@ -35,8 +35,10 @@ class InstanceNormalization(BackendHandler):
     inputs_rank = inputs.shape.ndims
 
     moments_axes = list(range(inputs_rank))[2:]
-    params_shape_broadcast = list(
-        [1, inputs_shape[1]] + [1 for _ in range(2, inputs_rank)])
+    channel_size = inputs_shape[
+        1] if inputs_shape[1] is not None else gamma.shape[0]
+    params_shape_broadcast = list([1, channel_size] +
+                                  [1 for _ in range(2, inputs_rank)])
 
     beta = tf.reshape(beta, params_shape_broadcast)
     gamma = tf.reshape(gamma, params_shape_broadcast)
@@ -47,8 +49,10 @@ class InstanceNormalization(BackendHandler):
     # Compute instance normalization.
     inputs = [inputs, mean, variance, beta, gamma]
     return [
-        cls.make_tensor_from_onnx_node(
-            node, inputs=inputs, name="instancenorm", **kwargs)
+        cls.make_tensor_from_onnx_node(node,
+                                       inputs=inputs,
+                                       name="instancenorm",
+                                       **kwargs)
     ]
 
   @classmethod


### PR DESCRIPTION
Fix InstanceNormalization unknown channel size issue where the
reshape will fail due to unknown size. The scale shape will be
used in this case now.

This patch should fix https://github.com/onnx/onnx-tensorflow/issues/886

Signed-off-by: Chin Huang <chhuang@us.ibm.com>