### PR TITLE
Fix a bug in slice operator

### DIFF
--- a/onnx_tf/handlers/backend/slice.py
+++ b/onnx_tf/handlers/backend/slice.py
@@ -22,8 +22,8 @@ class Slice(BackendHandler):
     slice_len = len(starts)
     axes = node.attrs.get("axes", list(range(slice_len)))
 
-    updated_full_sizes = [0] * len(full_sizes)
-    updated_full_begin = [0] * len(full_sizes)
+    updated_full_sizes = [0] * len(x.get_shape())
+    updated_full_begin = [0] * len(x.get_shape())
     updated_starts = [0] * slice_len
     updated_ends = [0] * slice_len
 


### PR DESCRIPTION
The len() method was used on a tensor's shpae, which is no longer legal in TF2.