### PR TITLE
Add suppor for ONNX model with external data

### DIFF
--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -26,9 +26,9 @@ optional arguments:
 
 More information: `onnx-tf convert -h`
 ```
-usage: onnx-tf [-h] --infile INFILE --outdir OUTDIR [--device DEVICE]
-               [--strict STRICT] [--logging_level LOGGING_LEVEL]
-               [--auto_cast AUTO_CAST]
+usage: onnx-tf [-h] --infile INFILE --outdir OUTDIR [--extdatadir EXTDATADIR]
+               [--device DEVICE] [--strict STRICT]
+               [--logging_level LOGGING_LEVEL] [--auto_cast AUTO_CAST]
 
 This is the converter for converting protocol buffer between tf and onnx.
 
@@ -38,6 +38,8 @@ optional arguments:
                         Input file path.
   --outdir OUTDIR, -o OUTDIR
                         Output directory.
+  --extdatadir EXTDATADIR, -e EXTDATADIR
+                        External input data file directory.
 
 backend arguments (onnx -> tf):
   --device DEVICE       The device to execute this model on. It can be either


### PR DESCRIPTION
Add suppor for ONNX model with external data with a new optional
command line argument to specify the external data directory.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>