### PR TITLE
update Optional operator to return right type value for empty value

### DIFF
--- a/onnx_tf/handlers/backend/optional.py
+++ b/onnx_tf/handlers/backend/optional.py
@@ -10,4 +10,8 @@ class Optional(BackendHandler):
     if len(node.inputs) > 0:
         return [kwargs["tensor_dict"][node.inputs[0]]]
     else:
-        return [None]
+        if node.attrs.get('type').optional_type.elem_type.HasField('tensor_type'):
+            return [None]
+        else:
+            return [[]]
+

--- a/test/backend/test_node.py
+++ b/test/backend/test_node.py
@@ -4199,7 +4199,7 @@ class TestNode(unittest.TestCase):
     np.testing.assert_almost_equal(output["Z"], np.where(c, x, y))
 
   def test_optional(self):
-    if legacy_opset_pre_ver(16):
+    if legacy_opset_pre_ver(15):
       raise unittest.SkipTest("ONNX version {} doesn't support Optional.".format(
           defs.onnx_opset_version()))
     ten_in_tp = helper.make_tensor_type_proto(TensorProto.FLOAT, shape=[5])
@@ -4210,13 +4210,25 @@ class TestNode(unittest.TestCase):
     np.testing.assert_almost_equal(output["Y"], x)
 
   def test_optional_empty(self):
-    if legacy_opset_pre_ver(16):
+    if legacy_opset_pre_ver(15):
       raise unittest.SkipTest("ONNX version {} doesn't support Optional.".format(
           defs.onnx_opset_version()))
     ten_in_tp = helper.make_tensor_type_proto(TensorProto.FLOAT, shape=[5])
     opt_in_tp = helper.make_optional_type_proto(ten_in_tp)
     node_def = helper.make_node("Optional", ["X"], ["Y"], type=opt_in_tp)
     x = None
+    output = run_node(node_def, [x])
+    np.testing.assert_equal(output["Y"], x)
+
+  def test_optional_sequence_empty(self):
+    if legacy_opset_pre_ver(15):
+      raise unittest.SkipTest("ONNX version {} doesn't support Optional.".format(
+          defs.onnx_opset_version()))
+    ten_in_tp = helper.make_tensor_type_proto(TensorProto.FLOAT, shape=[5])
+    seq_in_tp = helper.make_sequence_type_proto(ten_in_tp)
+    opt_in_tp = helper.make_optional_type_proto(seq_in_tp)
+    node_def = helper.make_node("Optional", ["X"], ["Y"], type=opt_in_tp)
+    x = []
     output = run_node(node_def, [x])
     np.testing.assert_equal(output["Y"], x)
     


### PR DESCRIPTION
Signed-off-by: degaochu <degaochu@cn.ibm.com>

Return None for tensor type and return [] for sequence type.

https://github.com/onnx/onnx/blob/master/docs/Operators.md#Optional
Optional
Constructs an optional-type value containing either an empty optional of a certain type specified by the attribute

Type Constraints
V : tensor(uint8), tensor(uint16), tensor(uint32), tensor(uint64), tensor(int8), tensor(int16), tensor(int32), tensor(int64), tensor(float16), tensor(float), tensor(double), tensor(string), tensor(bool), tensor(complex64), tensor(complex128), seq(tensor(uint8)), seq(tensor(uint16)), seq(tensor(uint32)), seq(tensor(uint64)), seq(tensor(int8)), seq(tensor(int16)), seq(tensor(int32)), seq(tensor(int64)), seq(tensor(float16)), seq(tensor(float)), seq(tensor(double)), seq(tensor(string)), seq(tensor(bool)), seq(tensor(complex64)), seq(tensor(complex128))
    Constrains input type to all tensor and sequence types.

