### PR TITLE
Update Tensorflow (2.8.0) and ONNX (1.10.2) versions

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -15,22 +15,22 @@ jobs:
         # - use pinned versions for current onnx-tf release
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9]
-        onnx-version: ['onnx==1.9.0']
-        tensorflow-version: ['tensorflow==2.6.2 tensorflow-addons==0.14.0 tensorflow_probability==0.14.0']
+        onnx-version: ['onnx==1.10.2']
+        tensorflow-version: ['tensorflow==2.8.0 tensorflow-addons==0.16.1 tensorflow_probability==0.16.0']
         include:
           - # Test previous versions on Linux only (regression)
             # - use pinned versions for previous onnx-tf release
             os: ubuntu-latest
             python-version: 3.8
-            onnx-version: 'onnx==1.9.0'
-            tensorflow-version: 'tensorflow==2.6.2 tensorflow-addons==0.14.0 tensorflow_probability==0.14.0'
+            onnx-version: 'onnx==1.10.2'
+            tensorflow-version: 'tensorflow==2.8.0 tensorflow-addons==0.16.1 tensorflow_probability==0.16.0'
           - # Test development versions on Linux only
             # - latest development versions
             # - allow failure via GitHub branch protection rule
             os: ubuntu-latest
             python-version: 3.9
             onnx-version: 'development'
-            tensorflow-version: 'tensorflow tensorflow-addons tensorflow_probability==0.14.0'
+            tensorflow-version: 'tensorflow tensorflow-addons tensorflow_probability'
 
     steps:
     - name: Checkout ONNX-TF

--- a/.github/workflows/test-modelzoo.yml
+++ b/.github/workflows/test-modelzoo.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: '3.8'
     - name: Install dependencies
       run: |
-        pip install onnx==1.9.0 tensorflow==2.6.2 tensorflow-addons==0.14.0 tensorflow_probability==0.14.0
+        pip install onnx==1.10.2 tensorflow==2.8.0 tensorflow-addons==0.16.1 tensorflow_probability==0.16.0
         pip install -e .
     - name: Run ModelZoo tests
       run: |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The specific ONNX release version that we support in the master branch of ONNX-T
 
 To install the latest version of ONNX-TF via pip, run `pip install onnx-tf`.
 
-Because users often have their own preferences for which variant of TensorFlow to install (i.e., a GPU version instead of a CPU version), we do not explicitly require tensorflow in the installation script. It is therefore users' responsibility to ensure that the proper variant of TensorFlow is available to ONNX-TF. Moreover, we require TensorFlow version == 2.6.0.
+Because users often have their own preferences for which variant of TensorFlow to install (i.e., a GPU version instead of a CPU version), we do not explicitly require tensorflow in the installation script. It is therefore users' responsibility to ensure that the proper variant of TensorFlow is available to ONNX-TF. Moreover, we require TensorFlow version == 2.8.0.
 
 ## Development
 
@@ -53,7 +53,7 @@ Because users often have their own preferences for which variant of TensorFlow t
 
 ### Installation
 - Install ONNX master branch from source.
-- Install TensorFlow >= 2.6.0,tensorflow-probability and tensorflow-addons. (Note TensorFlow 1.x is no longer supported)
+- Install TensorFlow >= 2.8.0, tensorflow-probability and tensorflow-addons. (Note TensorFlow 1.x is no longer supported)
 - Run `git clone https://github.com/onnx/onnx-tensorflow.git && cd onnx-tensorflow`.
 - Run `pip install -e .`.
 

--- a/doc/support_status.md
+++ b/doc/support_status.md
@@ -1,9 +1,9 @@
 # ONNX-Tensorflow Support Status
 |||
 |-:|:-|
-|ONNX-Tensorflow Version|Master ( commit id: 3847bb0975ce2047d9915af6a35fc6f6a87eed25 )|
-|ONNX Version|Master ( commit id: 65974860e20b311d14b642ce22b5a56b8c176ca5 )|
-|Tensorflow Version|v2.7.0|
+|ONNX-Tensorflow Version|Master ( commit id: 3f87e6235c96f2f66e523d95dc35ff4802862231 )|
+|ONNX Version|Master ( commit id: c9d61b6730c153f6e47faaed30dd0d9d8492c5d5 )|
+|Tensorflow Version|v2.8.0|
 
 Notes:
 * Values that are new or updated from a previous opset version are in bold.
@@ -71,7 +71,7 @@ Notes:
 |GlobalLpPool|**1**|**2**|2|2|2|2|2|2|2|2|2|2|2|2|2|2|GlobalLpPool|
 |GlobalMaxPool|**1**|1|1|1|1|1|1|1|1|1|1|1|1|1|1|1|GlobalMaxPool|
 |Greater|**1**|1|1|1|1|1|**7**|7|**9**|9|9|9|**13**|13|13|13|Greater|
-|GreaterOrEqual|-|-|-|-|-|-|-|-|-|-|-|**12**|12|12|12|12|GreaterOrEqual|
+|GreaterOrEqual|-|-|-|-|-|-|-|-|-|-|-|**12**|12|12|12|**16**:small_red_triangle:|GreaterOrEqual|
 |GridSample|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|**16**:small_red_triangle:|GridSample|
 |HardSigmoid|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|6|6|6|HardSigmoid|
 |HardSwish|-|-|-|-|-|-|-|-|-|-|-|-|-|**14**|14|14|HardSwish|
@@ -83,9 +83,9 @@ Notes:
 |IsNaN|-|-|-|-|-|-|-|-|**9**|9|9|9|**13**|13|13|13|IsNaN|
 |LRN|**1**|1|1|1|1|1|1|1|1|1|1|1|**13**|13|13|13|LRN|
 |LSTM|**1**:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|1:small_orange_diamond:|**7**:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|7:small_orange_diamond:|**14**:small_orange_diamond:|14:small_orange_diamond:|14:small_orange_diamond:|LSTM|
-|LeakyRelu|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|6|6|6|LeakyRelu|
+|LeakyRelu|**1**|1|1|1|1|**6**|6|6|6|6|6|6|6|6|6|**16**:small_red_triangle:|LeakyRelu|
 |Less|**1**|1|1|1|1|1|**7**|7|**9**|9|9|9|**13**|13|13|13|Less|
-|LessOrEqual|-|-|-|-|-|-|-|-|-|-|-|**12**|12|12|12|12|LessOrEqual|
+|LessOrEqual|-|-|-|-|-|-|-|-|-|-|-|**12**|12|12|12|**16**:small_red_triangle:|LessOrEqual|
 |Log|**1**|1|1|1|1|**6**|6|6|6|6|6|6|**13**|13|13|13|Log|
 |LogSoftmax|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**|13|13|13|LogSoftmax|
 |Loop|**1**|1|1|1|1|1|1|1|1|1|**11**|11|**13**|13|13|**16**:small_red_triangle:|Loop|
@@ -113,7 +113,7 @@ Notes:
 |OptionalGetElement|-|-|-|-|-|-|-|-|-|-|-|-|-|-|**15**|15|OptionalGetElement|
 |OptionalHasElement|-|-|-|-|-|-|-|-|-|-|-|-|-|-|**15**|15|OptionalHasElement|
 |Or|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|7|7|7|Or|
-|PRelu|**1**|1|1|1|1|**6**|**7**|7|**9**|9|9|9|9|9|9|9|PRelu|
+|PRelu|**1**|1|1|1|1|**6**|**7**|7|**9**|9|9|9|9|9|9|**16**:small_red_triangle:|PRelu|
 |Pad|**1**|**2**|2|2|2|2|2|2|2|2|**11**|11|**13**|13|13|13|Pad|
 |Pow|**1**|1|1|1|1|1|**7**|7|7|7|7|**12**|**13**|13|**15**|15|Pow|
 |QLinearConv|-|-|-|-|-|-|-|-|-|**10**|10|10|10|10|10|10|QLinearConv|
@@ -142,7 +142,7 @@ Notes:
 |ReverseSequence|-|-|-|-|-|-|-|-|-|**10**|10|10|10|10|10|10|ReverseSequence|
 |RoiAlign|-|-|-|-|-|-|-|-|-|**10**:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|10:small_orange_diamond:|**16**:small_red_triangle:|RoiAlign|
 |Round|-|-|-|-|-|-|-|-|-|-|**11**|11|11|11|11|11|Round|
-|Scan|-|-|-|-|-|-|-|**8**|**9**|9|**11**|11|11|11|11|11|Scan|
+|Scan|-|-|-|-|-|-|-|**8**|**9**|9|**11**|11|11|11|11|**16**:small_red_triangle:|Scan|
 |Scatter|-|-|-|-|-|-|-|-|**9**|9|**11**\*|11\*|11\*|11\*|11\*|11\*|Scatter|
 |ScatterElements|-|-|-|-|-|-|-|-|-|-|**11**|11|**13**|13|13|**16**:small_red_triangle:|ScatterElements|
 |ScatterND|-|-|-|-|-|-|-|-|-|-|**11**|11|**13**|13|13|**16**:small_red_triangle:|ScatterND|
@@ -187,7 +187,7 @@ Notes:
 |Where|-|-|-|-|-|-|-|-|**9**|9|9|9|9|9|9|**16**:small_red_triangle:|Where|
 |Xor|**1**|1|1|1|1|1|**7**|7|7|7|7|7|7|7|7|7|Xor|
 
-ONNX-TF Supported Operators / ONNX Operators: 156 / 170
+ONNX-TF Supported Operators / ONNX Operators: 151 / 170
 
 Notes:
 1. BatchNormalization: BatchNormalization with training_mode=1 is not supported in Tensorflow converte.


### PR DESCRIPTION
Update Tensorflow and ONNX versions
tensorflow==2.8.0
tensorflow-addons==0.16.1
tensorflow-probability==0.16.0
onnx==1.10.2

Signed-off-by: Chin Huang <chhuang@us.ibm.com>