### PR TITLE
Fix input rank unknown issue for split

### DIFF
--- a/onnx_tf/handlers/backend/split.py
+++ b/onnx_tf/handlers/backend/split.py
@@ -15,8 +15,9 @@ class Split(BackendHandler):
   @classmethod
   def args_check(cls, node, **kwargs):
     axis = node.attrs.get("axis", 0)
-    x_rank =  len(kwargs["tensor_dict"][node.inputs[0]].get_shape().as_list())
-    if axis > x_rank - 1 or axis < -x_rank:
+    if kwargs["tensor_dict"][node.inputs[0]].get_shape().rank is not None:
+      x_rank =  len(kwargs["tensor_dict"][node.inputs[0]].get_shape().as_list())
+      if axis > x_rank - 1 or axis < -x_rank:
         raise ValueError("Axis is out of bound")
 
   @classmethod


### PR DESCRIPTION
Fix input rank unknown issue for split by checking the input
rank and skipping the validation when rank is unknown.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>