### PR TITLE
Declare dependency on tensorflow_probability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,9 @@ setuptools.setup(
     version=version,
     description=
     'Tensorflow backend for ONNX (Open Neural Network Exchange).',
-    install_requires=[onnx_dep, "PyYAML", "tensorflow_addons"],
+    install_requires=[
+        onnx_dep, "PyYAML", "tensorflow_addons", "tensorflow_probability"
+    ],
     entry_points={
         "console_scripts": [
             "onnx-tf=onnx_tf.cli:main",


### PR DESCRIPTION
Add `tensorflow_probability` to the `install_requires` list in `setup.py`, similarly to how we handle `tensorflow_addons`.

Fixes onnx/onnx-tensorflow#1015