### PR TITLE
Support NHWC compute format in concat and conv's pad op.

### DIFF
--- a/onnx_tf/handlers/backend/concat.py
+++ b/onnx_tf/handlers/backend/concat.py
@@ -3,7 +3,8 @@ import tensorflow as tf
 from onnx_tf.handlers.backend_handler import BackendHandler
 from onnx_tf.handlers.handler import onnx_op
 from onnx_tf.handlers.handler import tf_func
-
+from onnx_tf.common import get_data_format
+from onnx_tf.common import get_perm_from_formats
 
 @onnx_op("Concat")
 @tf_func(tf.concat)
@@ -12,7 +13,24 @@ class Concat(BackendHandler):
   @classmethod
   def _common(cls, node, **kwargs):
     inputs = [kwargs["tensor_dict"][inp] for inp in node.inputs]
-    return [cls.make_tensor_from_onnx_node(node, inputs=[inputs])]
+    rank = len(inputs[0].get_shape())
+    storage_format, compute_format = get_data_format(rank) if (rank >= 2 and rank <= 5) else ('', '')
+    if storage_format == compute_format:
+      return [cls.make_tensor_from_onnx_node(node, inputs=[inputs])]
+    else:
+      # Transpose from storage_format to compute_format and do concat.
+      # NOTE: it's assumed that all other operators will be run in `compute_format` as much as
+      # possible, so those redundant `transpose` operators can be resolved. 
+      inputs = [tf.transpose(x, get_perm_from_formats(storage_format, compute_format)) for x in inputs]
+      # adjust concat axis according to source and target layout format.
+      from copy import deepcopy
+      attrs = deepcopy(node.attrs)
+      axis = attrs["axis"]
+      axis = compute_format.index(storage_format[axis])
+      attrs["axis"] = axis
+      output = cls.make_tensor_from_onnx_node(node, inputs=[inputs], attrs=attrs)
+      output = [tf.transpose(output, get_perm_from_formats(compute_format, storage_format))]
+      return output
 
   @classmethod
   def version_1(cls, node, **kwargs):

--- a/onnx_tf/handlers/backend/pad_mixin.py
+++ b/onnx_tf/handlers/backend/pad_mixin.py
@@ -5,13 +5,23 @@ import tensorflow as tf
 class PadMixin(object):
 
   @classmethod
-  def get_padding_as_op(cls, x, pads):
+  def get_padding_as_op(cls, x, pads, format:str=None):
     num_dim = int(len(pads) / 2)
 
-    tf_pads = np.transpose(np.array(pads).reshape([2, num_dim]))
-    tf_pads = [0, 0, 0, 0] + tf_pads.flatten().tolist()
+    # tf_pads = np.transpose(np.array(pads).reshape([2, num_dim]))
+    if format is None:
+      NIdx, CIdx = 0, 1
+    else:
+      assert "N" in format and "C" in format, "expected `N` and `C` in padding op's input format " \
+                                              "if given"
+      NIdx = format.index("N")
+      CIdx = format.index("C")
+    # create an empty tf_pads array
+    tf_pads = np.zeros([num_dim + 2, 2], dtype=np.int32)
+    # the indices of spatial axes in input format.
+    spatial_indices = [axis for axis in range(num_dim + 2) if axis not in [NIdx, CIdx]]
+    # fill pads into tf_pads's spatial axes
+    tf_pads[spatial_indices, :] = np.transpose(np.array(pads).reshape([2, num_dim]))
 
-    padding = tf.constant(
-        np.array(tf_pads).reshape([num_dim + 2, 2])
-        .astype(np.int32))  # tf requires int32 paddings
+    padding = tf.constant(tf_pads)  # tf requires int32 paddings
     return tf.pad(x, padding)


### PR DESCRIPTION
This MR add NHWC support to `Concat` operator, and `Pad` operator created by `Conv`.

### Original behaviour
#### Concat
Concat didn't support NHWC format, so tensors must be transposed back to NCHW before concat, and may be converted to NHWC to do other compuation.
![image](https://github.com/onnx/onnx-tensorflow/assets/6189820/48598283-6628-4396-a056-4d64fd32f518)

####  Pad of Conv
When explicit padding is used in Conv, the pad was done before input tensor was transposed, which also leads to a pair of unresolvable `Transpose` operators.
![image](https://github.com/onnx/onnx-tensorflow/assets/6189820/c49855ae-5414-4847-974e-a5e508eb4218)

### Changes
This MR added NHWC support to `concat` operator, and pad was done on transposed input of conv.
![image](https://github.com/onnx/onnx-tensorflow/assets/6189820/4f288cfc-60e6-4511-8a6a-ac1fa1395036)
